### PR TITLE
Update redis.tf

### DIFF
--- a/redis.tf
+++ b/redis.tf
@@ -13,4 +13,5 @@ resource "google_redis_instance" "tfe" {
   authorized_network      = data.google_compute_network.vpc.self_link
   connect_mode            = var.redis_connect_mode
   labels                  = var.common_labels
+  depends_on = [google_service_networking_connection.postgres_endpoint]
 }


### PR DESCRIPTION
## Description
This pull request adds a dependency on the Postgres endpoint connection for the Google Redis instance resource. The change ensures that the Redis instance is created only after the Postgres endpoint connection is established, resolving potential dependency issues during infrastructure deployment.
Added depends_on = [google_service_networking_connection.postgres_endpoint] to the google_redis_instance resource.

## Related issue
 Error creating Instance: googleapi: Error 400: com.google.apps.framework.request.StatusException: <eye3 title='FAILED_PRECONDITION'/> generic::FAILED_PRECONDITION: Google private service access is not enabled. Enable private service access and try again.
│
│  with module.tfe_fdo_default.google_redis_instance.tfe[0],
│  on ../../redis.tf line 1, in resource "google_redis_instance" "tfe":
│  1: resource "google_redis_instance" "tfe" {

## Type of change
- [x ] Bug fix (non-breaking change which fixes an issue)


## How has this been tested?
- [Describe the tests you ran to verify your changes]
-  terraform apply, and infrastructure works smoothly 
- [Provide any results or outcomes from the tests]
- Result: Apply complete! Resources: 9 added, 0 changed, 0 destroyed.
- [Include any additional notes related to the tests]

## Checklist
- [x ] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation
- [ x] My changes generate no new warnings
- [ x] I have added tests that prove my fix is effective or that my feature works
- [ x] New and existing unit tests pass locally with my changes
- [ x] Any dependent changes have been merged and published in downstream modules

## Additional notes
[Add any additional information or context about the PR here]
