### PR TITLE
Fix broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,12 +126,12 @@ One of the following logging destinations:
 
 Below are links to docs pages related to deployment customizations as well as managing day 2 operations of your TFE instance.
 
-- [deployment-customizations.md](https://raw.githubusercontent.com/hashicorp/terraform-google-terraform-enterprise-hvd/main/docs/deployment-customizations.md)
-- [operations.md](https://raw.githubusercontent.com/hashicorp/terraform-google-terraform-enterprise-hvd/main/docs/operations.md)
-- [tfe-tls-cert-rotation.md](https://raw.githubusercontent.com/hashicorp/terraform-google-terraform-enterprise-hvd/main/docs/tfe-tls-cert-rotation.md)
-- [tfe-config-settings.md](https://raw.githubusercontent.com/hashicorp/terraform-google-terraform-enterprise-hvd/main/docs/tfe-config-settings.md)
-- [tfe-version-upgrades.md](https://raw.githubusercontent.com/hashicorp/terraform-google-terraform-enterprise-hvd/main/docs/tfe-version-upgrades.md)
-- [troubleshooting.md](https://raw.githubusercontent.com/hashicorp/terraform-google-terraform-enterprise-hvd/main/docs/troubleshooting.md)
+- [deployment-customizations.md](https://github.com/hashicorp/terraform-google-terraform-enterprise-hvd/tree/main/docs/deployment-customizations.md)
+- [operations.md](https://github.com/hashicorp/terraform-google-terraform-enterprise-hvd/tree/main/docs/operations.md)
+- [tfe-tls-cert-rotation.md](https://github.com/hashicorp/terraform-google-terraform-enterprise-hvd/tree/main/docs/tfe-tls-cert-rotation.md)
+- [tfe-config-settings.md](https://github.com/hashicorp/terraform-google-terraform-enterprise-hvd/tree/main/docs/tfe-config-settings.md)
+- [tfe-version-upgrades.md](https://github.com/hashicorp/terraform-google-terraform-enterprise-hvd/tree/main/docs/tfe-version-upgrades.md)
+- [troubleshooting.md](https://github.com/hashicorp/terraform-google-terraform-enterprise-hvd/tree/main/docs/troubleshooting.md)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ One of the following logging destinations:
 
 1. Create/configure/validate the applicable [prerequisites](#prerequisites).
 
-2. Nested within the [examples](https://raw.githubusercontent.com/hashicorp/terraform-google-terraform-enterprise-hvd/main/examples/) directory are subdirectories containing ready-made Terraform configurations for example scenarios on how to call and deploy this module. To get started, choose the example scenario that most closely matches your requirements. You can customize your deployment later by adding additional module [inputs](#inputs) as you see fit (see the [Deployment-Customizations](https://raw.githubusercontent.com/hashicorp/terraform-google-terraform-enterprise-hvd/main/docs/deployment-customizations.md) doc for more details).
+2. Nested within the [examples](https://github.com/hashicorp/terraform-google-terraform-enterprise-hvd/tree/main/examples/) directory are subdirectories containing ready-made Terraform configurations for example scenarios on how to call and deploy this module. To get started, choose the example scenario that most closely matches your requirements. You can customize your deployment later by adding additional module [inputs](#inputs) as you see fit (see the [Deployment-Customizations](https://github.com/hashicorp/terraform-google-terraform-enterprise-hvd/tree/main/docs/deployment-customizations.md) doc for more details).
 
 3. Copy all of the Terraform files from your example scenario of choice into a new destination directory to create your Terraform configuration that will manage your TFE deployment. This is a common directory structure for managing multiple TFE deployments:
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ One of the following logging destinations:
 
 1. Create/configure/validate the applicable [prerequisites](#prerequisites).
 
-2. Nested within the [examples](./examples/) directory are subdirectories containing ready-made Terraform configurations for example scenarios on how to call and deploy this module. To get started, choose the example scenario that most closely matches your requirements. You can customize your deployment later by adding additional module [inputs](#inputs) as you see fit (see the [Deployment-Customizations](./docs/deployment-customizations.md) doc for more details).
+2. Nested within the [examples](https://raw.githubusercontent.com/hashicorp/terraform-google-terraform-enterprise-hvd/main/examples/) directory are subdirectories containing ready-made Terraform configurations for example scenarios on how to call and deploy this module. To get started, choose the example scenario that most closely matches your requirements. You can customize your deployment later by adding additional module [inputs](#inputs) as you see fit (see the [Deployment-Customizations](https://raw.githubusercontent.com/hashicorp/terraform-google-terraform-enterprise-hvd/main/docs/deployment-customizations.md) doc for more details).
 
 3. Copy all of the Terraform files from your example scenario of choice into a new destination directory to create your Terraform configuration that will manage your TFE deployment. This is a common directory structure for managing multiple TFE deployments:
 
@@ -126,12 +126,12 @@ One of the following logging destinations:
 
 Below are links to docs pages related to deployment customizations as well as managing day 2 operations of your TFE instance.
 
-- [deployment-customizations.md](./docs/deployment-customizations.md)
-- [operations.md](./docs/operations.md)
-- [tfe-tls-cert-rotation.md](./docs/tfe-tls-cert-rotation.md)
-- [tfe-config-settings.md](./docs/tfe-config-settings.md)
-- [tfe-version-upgrades.md](./docs/tfe-version-upgrades.md)
-- [troubleshooting.md](./docs/troubleshooting.md)
+- [deployment-customizations.md](https://raw.githubusercontent.com/hashicorp/terraform-google-terraform-enterprise-hvd/main/docs/deployment-customizations.md)
+- [operations.md](https://raw.githubusercontent.com/hashicorp/terraform-google-terraform-enterprise-hvd/main/docs/operations.md)
+- [tfe-tls-cert-rotation.md](https://raw.githubusercontent.com/hashicorp/terraform-google-terraform-enterprise-hvd/main/docs/tfe-tls-cert-rotation.md)
+- [tfe-config-settings.md](https://raw.githubusercontent.com/hashicorp/terraform-google-terraform-enterprise-hvd/main/docs/tfe-config-settings.md)
+- [tfe-version-upgrades.md](https://raw.githubusercontent.com/hashicorp/terraform-google-terraform-enterprise-hvd/main/docs/tfe-version-upgrades.md)
+- [troubleshooting.md](https://raw.githubusercontent.com/hashicorp/terraform-google-terraform-enterprise-hvd/main/docs/troubleshooting.md)
 
 ---
 


### PR DESCRIPTION
## Description
Links in the README with relative paths are causing 404s for users consuming the public registry. This PR fixes them to absolute paths.

## Related issue
Highlighted in [this issue for the terraform-aws-terraform-enterprise-hvd module](https://github.com/hashicorp/terraform-aws-terraform-enterprise-hvd/issues/8)

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [x] This change requires a documentation update

## How has this been tested?
- Vercel rendering pending
- Reconcile all link changes with Vercel

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional notes
Links still need testing.