### PR TITLE
feat!: remove deprecated tfe_database_reconnect_enabled variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,6 @@ Please note that there is no official Service Level Agreement (SLA) for support 
 | <a name="input_tfe_capacity_memory"></a> [tfe\_capacity\_memory](#input\_tfe\_capacity\_memory) | Maximum amount of memory (in MiB) that a Terraform run is allowed to consume on a TFE node. | `number` | `2048` | no |
 | <a name="input_tfe_database_name"></a> [tfe\_database\_name](#input\_tfe\_database\_name) | Name of TFE PostgreSQL database to create. | `string` | `"tfe"` | no |
 | <a name="input_tfe_database_parameters"></a> [tfe\_database\_parameters](#input\_tfe\_database\_parameters) | Additional parameters to pass into the TFE database settings for the PostgreSQL connection URI. | `string` | `"sslmode=require"` | no |
-| <a name="input_tfe_database_reconnect_enabled"></a> [tfe\_database\_reconnect\_enabled](#input\_tfe\_database\_reconnect\_enabled) | Boolean to enable database reconnection in the event of a TFE PostgreSQL database cluster failover. | `bool` | `true` | no |
 | <a name="input_tfe_database_user"></a> [tfe\_database\_user](#input\_tfe\_database\_user) | Name of TFE PostgreSQL database user to create. | `string` | `"tfe"` | no |
 | <a name="input_tfe_hairpin_addressing"></a> [tfe\_hairpin\_addressing](#input\_tfe\_hairpin\_addressing) | Boolean to enable hairpin addressing within TFE container networking for loopback prevention with a layer 4 internal load balancer. | `bool` | `true` | no |
 | <a name="input_tfe_http_port"></a> [tfe\_http\_port](#input\_tfe\_http\_port) | HTTP port for TFE application containers to listen on. | `number` | `8080` | no |

--- a/compute.tf
+++ b/compute.tf
@@ -21,7 +21,7 @@ locals {
 #-----------------------------------------------------------------------------------
 locals {
   tfe_startup_script_tpl = var.custom_tfe_startup_script_template != null ? "${path.cwd}/templates/${var.custom_tfe_startup_script_template}" : "${path.module}/templates/tfe_startup_script.sh.tpl"
-  redis_port = var.redis_transit_encryption_mode == "SERVER_AUTHENTICATION" ? "6378" : "6379"
+  redis_port             = var.redis_transit_encryption_mode == "SERVER_AUTHENTICATION" ? "6378" : "6379"
 
   startup_script_args = {
     # Bootstrap
@@ -32,7 +32,7 @@ locals {
     tfe_tls_ca_bundle_secret_id       = var.tfe_tls_ca_bundle_secret_id
     tfe_image_repository_url          = var.tfe_image_repository_url
     tfe_image_repository_username     = var.tfe_image_repository_username
-    tfe_image_repository_password     = var.tfe_image_repository_password != null ? var.tfe_image_repository_password : "" 
+    tfe_image_repository_password     = var.tfe_image_repository_password != null ? var.tfe_image_repository_password : ""
     tfe_image_name                    = var.tfe_image_name
     tfe_image_tag                     = var.tfe_image_tag
     container_runtime                 = var.container_runtime
@@ -48,18 +48,18 @@ locals {
     tfe_license_reporting_opt_out = var.tfe_license_reporting_opt_out
     tfe_usage_reporting_opt_out   = var.tfe_usage_reporting_opt_out
     tfe_run_pipeline_driver       = "docker"
-    tfe_run_pipeline_image        = var.tfe_run_pipeline_image != null ? var.tfe_run_pipeline_image : "" 
+    tfe_run_pipeline_image        = var.tfe_run_pipeline_image != null ? var.tfe_run_pipeline_image : ""
     tfe_backup_restore_token      = ""
     tfe_node_id                   = ""
     tfe_http_port                 = var.tfe_http_port
     tfe_https_port                = var.tfe_https_port
 
     # Database settings
-    tfe_database_host              = "${google_sql_database_instance.tfe.private_ip_address}:5432"
-    tfe_database_name              = var.tfe_database_name
-    tfe_database_user              = var.tfe_database_user
-    tfe_database_password          = data.google_secret_manager_secret_version.tfe_database_password.secret_data
-    tfe_database_parameters        = var.tfe_database_parameters
+    tfe_database_host       = "${google_sql_database_instance.tfe.private_ip_address}:5432"
+    tfe_database_name       = var.tfe_database_name
+    tfe_database_user       = var.tfe_database_user
+    tfe_database_password   = data.google_secret_manager_secret_version.tfe_database_password.secret_data
+    tfe_database_parameters = var.tfe_database_parameters
 
     # Object storage settings
     tfe_object_storage_type               = "google"
@@ -90,7 +90,7 @@ locals {
     fluent_bit_rendered_config = local.fluent_bit_rendered_config
 
     # Docker driver settings
-    tfe_run_pipeline_docker_network = var.tfe_run_pipeline_docker_network != null ? var.tfe_run_pipeline_docker_network : "" 
+    tfe_run_pipeline_docker_network = var.tfe_run_pipeline_docker_network != null ? var.tfe_run_pipeline_docker_network : ""
     tfe_hairpin_addressing          = var.tfe_hairpin_addressing
     #tfe_run_pipeline_docker_extra_hosts = "" // computed inside of tfe_user_data script if `tfe_hairpin_addressing` is `true` because VM private IP is needed
 
@@ -184,7 +184,7 @@ resource "google_compute_region_instance_group_manager" "tfe" {
     instance_redistribution_type   = "PROACTIVE"
     max_surge_fixed                = length(data.google_compute_zones.up.names)
     max_unavailable_fixed          = length(data.google_compute_zones.up.names)
-    replacement_method             = "SUBSTITUTE" 
+    replacement_method             = "SUBSTITUTE"
   }
 }
 
@@ -227,7 +227,7 @@ resource "google_compute_firewall" "vm_allow_ingress_ssh_from_cidr" {
 
 resource "google_compute_firewall" "vm_allow_ingress_ssh_from_iap" {
   count = var.allow_ingress_vm_ssh_from_iap ? 1 : 0
-  
+
   name        = "${var.friendly_name_prefix}-tfe-allow-ssh-from-iap"
   description = "Allow TCP/22 ingress to TFE GCE VM instances from IAP."
   network     = data.google_compute_network.vpc.self_link
@@ -248,7 +248,7 @@ resource "google_compute_firewall" "vm_allow_ingress_ssh_from_iap" {
 
 resource "google_compute_firewall" "vm_allow_tfe_443" {
   count = var.cidr_allow_ingress_tfe_443 != null ? 1 : 0
-  
+
   name        = "${var.friendly_name_prefix}-tfe-allow-443"
   description = "Allow TCP/443 (HTTPS) ingress to TFE GCE VM instances from specified CIDR ranges."
   network     = data.google_compute_network.vpc.self_link
@@ -293,7 +293,7 @@ resource "google_compute_firewall" "vm_allow_lb_health_checks_443" {
 
 resource "google_compute_firewall" "vm_tfe_self_allow" {
   count = var.tfe_operational_mode == "active-active" ? 1 : 0
-  
+
   name        = "${var.friendly_name_prefix}-tfe-self-allow"
   description = "Allow TFE GCE VM instances to communicate with each other over TCP/8201 (Vault cluster) when TFE operational mode is active-active."
   network     = data.google_compute_network.vpc.self_link

--- a/compute.tf
+++ b/compute.tf
@@ -60,7 +60,6 @@ locals {
     tfe_database_user              = var.tfe_database_user
     tfe_database_password          = data.google_secret_manager_secret_version.tfe_database_password.secret_data
     tfe_database_parameters        = var.tfe_database_parameters
-    tfe_database_reconnect_enabled = var.tfe_database_reconnect_enabled
 
     # Object storage settings
     tfe_object_storage_type               = "google"

--- a/data.tf
+++ b/data.tf
@@ -33,6 +33,6 @@ data "google_compute_subnetwork" "vm_subnet" {
 
 data "google_compute_subnetwork" "lb_subnet" {
   count = var.lb_subnet_name != null ? 1 : 0
-  
+
   name = var.lb_subnet_name
 }

--- a/examples/docker-ubuntu-internal-nlb/outputs.tf
+++ b/examples/docker-ubuntu-internal-nlb/outputs.tf
@@ -5,13 +5,13 @@
 # TFE URLs
 #------------------------------------------------------------------------------
 output "tfe_url" {
-  value       = module.tfe.tfe_url
+  value = module.tfe.tfe_url
 }
 
 output "tfe_retrieve_iact_url" {
-  value       = module.tfe.tfe_retrieve_iact_url
+  value = module.tfe.tfe_retrieve_iact_url
 }
 
 output "tfe_create_initial_admin_user_url" {
-  value       = module.tfe.tfe_create_initial_admin_user_url
+  value = module.tfe.tfe_create_initial_admin_user_url
 }

--- a/examples/docker-ubuntu-internal-nlb/variables.tf
+++ b/examples/docker-ubuntu-internal-nlb/variables.tf
@@ -17,7 +17,7 @@ variable "region" {
 variable "friendly_name_prefix" {
   type        = string
   description = "Friendly name prefix used for uniquely naming all GCP resources for this deployment. Most commonly set to either an environment (e.g. 'sandbox', 'prod'), a team name, or a project name."
-  
+
   validation {
     condition     = !strcontains(var.friendly_name_prefix, "tfe")
     error_message = "Value must not contain the substring 'tfe' to avoid redundancy in resource naming."
@@ -528,10 +528,10 @@ variable "gcs_location" {
   description = "Location of TFE GCS bucket to create."
   default     = "US"
 
-  validation { 
+  validation {
     condition     = var.gcs_storage_class == "MULTI_REGIONAL" ? contains(["US", "EU", "ASIA"], var.gcs_location) : true
     error_message = "Supported values are 'US', 'EU', and 'ASIA' when `gcs_storage_class` is `MULTI_REGIONAL`."
- }
+  }
 }
 
 variable "gcs_storage_class" {

--- a/examples/docker-ubuntu-internal-nlb/variables.tf
+++ b/examples/docker-ubuntu-internal-nlb/variables.tf
@@ -431,12 +431,6 @@ variable "tfe_database_parameters" {
   default     = "sslmode=require"
 }
 
-variable "tfe_database_reconnect_enabled" {
-  type        = bool
-  description = "Boolean to enable database reconnection in the event of a TFE PostgreSQL database cluster failover."
-  default     = true
-}
-
 variable "postgres_version" {
   type        = string
   description = "PostgreSQL version to use."

--- a/examples/podman-rhel-internal-nlb/outputs.tf
+++ b/examples/podman-rhel-internal-nlb/outputs.tf
@@ -5,13 +5,13 @@
 # TFE URLs
 #------------------------------------------------------------------------------
 output "tfe_url" {
-  value       = module.tfe.tfe_url
+  value = module.tfe.tfe_url
 }
 
 output "tfe_retrieve_iact_url" {
-  value       = module.tfe.tfe_retrieve_iact_url
+  value = module.tfe.tfe_retrieve_iact_url
 }
 
 output "tfe_create_initial_admin_user_url" {
-  value       = module.tfe.tfe_create_initial_admin_user_url
+  value = module.tfe.tfe_create_initial_admin_user_url
 }

--- a/examples/podman-rhel-internal-nlb/variables.tf
+++ b/examples/podman-rhel-internal-nlb/variables.tf
@@ -17,7 +17,7 @@ variable "region" {
 variable "friendly_name_prefix" {
   type        = string
   description = "Friendly name prefix used for uniquely naming all GCP resources for this deployment. Most commonly set to either an environment (e.g. 'sandbox', 'prod'), a team name, or a project name."
-  
+
   validation {
     condition     = !strcontains(var.friendly_name_prefix, "tfe")
     error_message = "Value must not contain the substring 'tfe' to avoid redundancy in resource naming."
@@ -528,10 +528,10 @@ variable "gcs_location" {
   description = "Location of TFE GCS bucket to create."
   default     = "US"
 
-  validation { 
+  validation {
     condition     = var.gcs_storage_class == "MULTI_REGIONAL" ? contains(["US", "EU", "ASIA"], var.gcs_location) : true
     error_message = "Supported values are 'US', 'EU', and 'ASIA' when `gcs_storage_class` is `MULTI_REGIONAL`."
- }
+  }
 }
 
 variable "gcs_storage_class" {

--- a/examples/podman-rhel-internal-nlb/variables.tf
+++ b/examples/podman-rhel-internal-nlb/variables.tf
@@ -431,12 +431,6 @@ variable "tfe_database_parameters" {
   default     = "sslmode=require"
 }
 
-variable "tfe_database_reconnect_enabled" {
-  type        = bool
-  description = "Boolean to enable database reconnection in the event of a TFE PostgreSQL database cluster failover."
-  default     = true
-}
-
 variable "postgres_version" {
   type        = string
   description = "PostgreSQL version to use."

--- a/iam.tf
+++ b/iam.tf
@@ -35,8 +35,8 @@ resource "google_secret_manager_secret_iam_member" "tfe_license" {
 }
 
 resource "google_secret_manager_secret_iam_member" "tfe_encryption_password" {
-  count     = var.tfe_encryption_password_secret_id != "" ? 1 : 0
-  
+  count = var.tfe_encryption_password_secret_id != "" ? 1 : 0
+
   secret_id = var.tfe_encryption_password_secret_id
   role      = "roles/secretmanager.secretAccessor"
   member    = "serviceAccount:${google_service_account.tfe.email}"
@@ -84,7 +84,7 @@ resource "google_project_service_identity" "gcp_project_cloud_sql_sa" {
   count    = var.postgres_kms_keyring_name != null ? 1 : 0
   provider = google-beta
 
-  service  = "sqladmin.googleapis.com"
+  service = "sqladmin.googleapis.com"
 }
 
 resource "google_kms_crypto_key_iam_member" "postgres_cmek" {

--- a/postgresql.tf
+++ b/postgresql.tf
@@ -4,7 +4,7 @@
 #------------------------------------------------------------------------------
 # Google Secret Manager - TFE database password lookup
 #------------------------------------------------------------------------------
-data "google_secret_manager_secret_version" "tfe_database_password" { 
+data "google_secret_manager_secret_version" "tfe_database_password" {
   secret = var.tfe_database_password_secret_id
 }
 
@@ -18,7 +18,7 @@ resource "random_id" "postgres_instance_suffix" {
 resource "google_sql_database_instance" "tfe" {
   name                = "${var.friendly_name_prefix}-tfe-postgres-${random_id.postgres_instance_suffix.hex}"
   database_version    = var.postgres_version
-  encryption_key_name = var.postgres_kms_cmek_name != null ? data.google_kms_crypto_key.postgres_cmek[0].id: null 
+  encryption_key_name = var.postgres_kms_cmek_name != null ? data.google_kms_crypto_key.postgres_cmek[0].id : null
   deletion_protection = var.postgres_deletetion_protection
 
   settings {

--- a/redis.tf
+++ b/redis.tf
@@ -6,7 +6,7 @@
 #------------------------------------------------------------------------------
 resource "google_redis_instance" "tfe" {
   count = var.tfe_operational_mode == "active-active" ? 1 : 0
-  
+
   name                    = "${var.friendly_name_prefix}-tfe-redis"
   display_name            = "${var.friendly_name_prefix}-tfe-redis"
   tier                    = var.redis_tier

--- a/templates/tfe_startup_script.sh.tpl
+++ b/templates/tfe_startup_script.sh.tpl
@@ -201,7 +201,6 @@ services:
       TFE_DATABASE_USER: ${tfe_database_user}
       TFE_DATABASE_PASSWORD: ${tfe_database_password}
       TFE_DATABASE_PARAMETERS: ${tfe_database_parameters}
-      TFE_DATABASE_RECONNECT_ENABLED: ${tfe_database_reconnect_enabled}
       
       # Object storage settings
       TFE_OBJECT_STORAGE_TYPE: ${tfe_object_storage_type}
@@ -361,8 +360,6 @@ spec:
       value: ${tfe_database_password}
     - name: "TFE_DATABASE_PARAMETERS"
       value: ${tfe_database_parameters}
-    - name: "TFE_DATABASE_RECONNECT_ENABLED"
-      value: ${tfe_database_reconnect_enabled}
 
     # Object storage settings
     - name: "TFE_OBJECT_STORAGE_TYPE"

--- a/variables.tf
+++ b/variables.tf
@@ -17,7 +17,7 @@ variable "region" {
 variable "friendly_name_prefix" {
   type        = string
   description = "Friendly name prefix used for uniquely naming all GCP resources for this deployment. Most commonly set to either an environment (e.g. 'sandbox', 'prod'), a team name, or a project name."
-  
+
   validation {
     condition     = !strcontains(var.friendly_name_prefix, "tfe")
     error_message = "Value must not contain the substring 'tfe' to avoid redundancy in resource naming."
@@ -528,10 +528,10 @@ variable "gcs_location" {
   description = "Location of TFE GCS bucket to create."
   default     = "US"
 
-  validation { 
+  validation {
     condition     = var.gcs_storage_class == "MULTI_REGIONAL" ? contains(["US", "EU", "ASIA"], var.gcs_location) : true
     error_message = "Supported values are 'US', 'EU', and 'ASIA' when `gcs_storage_class` is `MULTI_REGIONAL`."
- }
+  }
 }
 
 variable "gcs_storage_class" {

--- a/variables.tf
+++ b/variables.tf
@@ -431,12 +431,6 @@ variable "tfe_database_parameters" {
   default     = "sslmode=require"
 }
 
-variable "tfe_database_reconnect_enabled" {
-  type        = bool
-  description = "Boolean to enable database reconnection in the event of a TFE PostgreSQL database cluster failover."
-  default     = true
-}
-
 variable "postgres_version" {
   type        = string
   description = "PostgreSQL version to use."


### PR DESCRIPTION
Remove the tfe_database_reconnect_enabled variable which is deprecated in TFE May 2025 release.

This removes variables no longer supported, but does not implement any newly supported ones. Coverage for newly supported variables would be implemented separately.

Changes:
- Remove variable definition from variables.tf
- Remove variable reference from compute.tf template data
- Remove TFE_DATABASE_RECONNECT_ENABLED from startup script template
- Remove variable from example configurations
- Update module documentation

## Related issue
[https://hashicorp.atlassian.net/browse/HDM-26]

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How has this been tested?
- [Describe the tests you ran to verify your changes]
- [Provide any results or outcomes from the tests]
- [Include any additional notes related to the tests]

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional notes
[Add any additional information or context about the PR here]
