### PR TITLE
feat: add terraform enterprise explorer support

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ The following _bootstrap_ secrets stored in Google Secret Manager in order to bo
 - **TFE license file** - raw contents of license file (_e.g._ `cat terraform.hclic`)
 - **TFE encryption password** - random characters (used to protect TFE's internally-managed Vault unseal key and root token)
 - **TFE (PostgreSQL) database password** - random characters between 8 and 99 characters in length; must contain at least one uppercase letter, one lowercase letter, and one digit or special character
+- **Explorer (PostgreSQL) database password** (optional) - random characters between 8 and 99 characters in length; used when providing a separate Explorer database password secret via `tfe_explorer_database_password_secret_id`
 - **TFE TLS certificate** - certificate file in PEM format, base64-encoded into a string, and stored as a secret
 - **TFE TLS certificate private key** - private key file in PEM format, base64-encoded into a string, and stored as a secret
 - **TFE TLS CA bundle** - Ca bundle file in PEM format, base64-encoded into a string, and stored as a secret
@@ -184,18 +185,25 @@ Please note that there is no official Service Level Agreement (SLA) for support 
 | [google_kms_crypto_key_iam_member.gcp_project_gcs_sa_cmek](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/kms_crypto_key_iam_member) | resource |
 | [google_kms_crypto_key_iam_member.gcp_project_redis_sa_cmek](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/kms_crypto_key_iam_member) | resource |
 | [google_kms_crypto_key_iam_member.postgres_cmek](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/kms_crypto_key_iam_member) | resource |
+| [google_project_iam_member.tfe_cloudsql_instance_user](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_iam_member.tfe_logging_stackdriver](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_redis_instance.tfe](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/redis_instance) | resource |
 | [google_secret_manager_secret_iam_member.tfe_ca_bundle](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_iam_member) | resource |
 | [google_secret_manager_secret_iam_member.tfe_cert](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_iam_member) | resource |
 | [google_secret_manager_secret_iam_member.tfe_encryption_password](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_iam_member) | resource |
+| [google_secret_manager_secret_iam_member.tfe_explorer_database_password](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_iam_member) | resource |
 | [google_secret_manager_secret_iam_member.tfe_license](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_iam_member) | resource |
 | [google_secret_manager_secret_iam_member.tfe_privkey](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_iam_member) | resource |
 | [google_service_account.tfe](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
 | [google_service_account_key.tfe](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_key) | resource |
 | [google_sql_database.tfe](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_database) | resource |
+| [google_sql_database.tfe_explorer](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_database) | resource |
 | [google_sql_database_instance.tfe](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_database_instance) | resource |
+| [google_sql_database_instance.tfe_explorer](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_database_instance) | resource |
 | [google_sql_user.tfe](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_user) | resource |
+| [google_sql_user.tfe_explorer](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_user) | resource |
+| [google_sql_user.tfe_explorer_iam](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_user) | resource |
+| [google_sql_user.tfe_primary_explorer_iam](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_user) | resource |
 | [google_storage_bucket.tfe](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket) | resource |
 | [google_storage_bucket_iam_member.tfe_bucket_object_admin](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_iam_member) | resource |
 | [google_storage_bucket_iam_member.tfe_bucket_reader](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_iam_member) | resource |
@@ -216,6 +224,7 @@ Please note that there is no official Service Level Agreement (SLA) for support 
 | [google_kms_key_ring.redis_cmek](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/kms_key_ring) | data source |
 | [google_project.current](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/project) | data source |
 | [google_secret_manager_secret_version.tfe_database_password](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/secret_manager_secret_version) | data source |
+| [google_secret_manager_secret_version.tfe_explorer_database_password](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/secret_manager_secret_version) | data source |
 | [google_storage_project_service_account.gcp_project_gcs_sa](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/storage_project_service_account) | data source |
 
 ## Inputs
@@ -242,6 +251,7 @@ Please note that there is no official Service Level Agreement (SLA) for support 
 | <a name="input_common_labels"></a> [common\_labels](#input\_common\_labels) | Map of common labels to apply to all GCP resources. | `map(string)` | `{}` | no |
 | <a name="input_container_runtime"></a> [container\_runtime](#input\_container\_runtime) | Container runtime to use for TFE deployment. Supported values are `docker` or `podman`. | `string` | `"docker"` | no |
 | <a name="input_create_tfe_cloud_dns_record"></a> [create\_tfe\_cloud\_dns\_record](#input\_create\_tfe\_cloud\_dns\_record) | Boolean to create Google Cloud DNS record for TFE using the value of `tfe_fqdn` as the record name, resolving to the load balancer IP. `cloud_dns_managed_zone_name` is required when `true`. | `bool` | `false` | no |
+| <a name="input_create_tfe_explorer_db"></a> [create\_tfe\_explorer\_db](#input\_create\_tfe\_explorer\_db) | Boolean to create and use a module-managed dedicated Cloud SQL for PostgreSQL instance for Explorer when `tfe_explorer_enabled` is `true` and no explicit Explorer database host, name, and user values are provided. | `bool` | `true` | no |
 | <a name="input_custom_fluent_bit_config"></a> [custom\_fluent\_bit\_config](#input\_custom\_fluent\_bit\_config) | Custom Fluent Bit configuration for log forwarding. Only valid when `tfe_log_forwarding_enabled` is `true` and `log_fwd_destination_type` is `custom`. | `string` | `null` | no |
 | <a name="input_custom_tfe_startup_script_template"></a> [custom\_tfe\_startup\_script\_template](#input\_custom\_tfe\_startup\_script\_template) | Name of custom TFE startup script template file. File must exist within a directory named `./templates` within your current working directory. | `string` | `null` | no |
 | <a name="input_docker_version"></a> [docker\_version](#input\_docker\_version) | Version of Docker to install on TFE GCE VM instances. | `string` | `"26.1.4-1"` | no |
@@ -289,6 +299,13 @@ Please note that there is no official Service Level Agreement (SLA) for support 
 | <a name="input_tfe_database_name"></a> [tfe\_database\_name](#input\_tfe\_database\_name) | Name of TFE PostgreSQL database to create. | `string` | `"tfe"` | no |
 | <a name="input_tfe_database_parameters"></a> [tfe\_database\_parameters](#input\_tfe\_database\_parameters) | Additional parameters to pass into the TFE database settings for the PostgreSQL connection URI. | `string` | `"sslmode=require"` | no |
 | <a name="input_tfe_database_user"></a> [tfe\_database\_user](#input\_tfe\_database\_user) | Name of TFE PostgreSQL database user to create. | `string` | `"tfe"` | no |
+| <a name="input_tfe_explorer_database_auth_use_gcp_iam"></a> [tfe\_explorer\_database\_auth\_use\_gcp\_iam](#input\_tfe\_explorer\_database\_auth\_use\_gcp\_iam) | Boolean to use Google Cloud IAM database authentication for Explorer. | `bool` | `false` | no |
+| <a name="input_tfe_explorer_database_host"></a> [tfe\_explorer\_database\_host](#input\_tfe\_explorer\_database\_host) | PostgreSQL server for Explorer in `HOST[:PORT]` format. Leave as `null` to have the module create and use a dedicated Explorer Cloud SQL instance when `create_tfe_explorer_db` is `true`, or reuse the primary TFE Cloud SQL instance when `create_tfe_explorer_db` is `false`. | `string` | `null` | no |
+| <a name="input_tfe_explorer_database_name"></a> [tfe\_explorer\_database\_name](#input\_tfe\_explorer\_database\_name) | Name of the PostgreSQL database used by Explorer. Leave as `null` to have the module use the Explorer database name it manages when `create_tfe_explorer_db` is `true`, or reuse the primary TFE database name when `create_tfe_explorer_db` is `false`. | `string` | `null` | no |
+| <a name="input_tfe_explorer_database_parameters"></a> [tfe\_explorer\_database\_parameters](#input\_tfe\_explorer\_database\_parameters) | PostgreSQL server parameters for the Explorer connection URI. Leave as `null` to reuse `tfe_database_parameters`. | `string` | `null` | no |
+| <a name="input_tfe_explorer_database_password_secret_id"></a> [tfe\_explorer\_database\_password\_secret\_id](#input\_tfe\_explorer\_database\_password\_secret\_id) | Name of Google Secret Manager secret for the Explorer database password. Leave as `null` when `tfe_explorer_database_auth_use_gcp_iam` is `true` or to reuse the primary TFE database password for the module-managed Explorer database or shared primary-database fallback. | `string` | `null` | no |
+| <a name="input_tfe_explorer_database_user"></a> [tfe\_explorer\_database\_user](#input\_tfe\_explorer\_database\_user) | PostgreSQL username used by Explorer. Leave as `null` to have the module use the Explorer database user it manages when `create_tfe_explorer_db` is `true`, or reuse the primary TFE database user when `create_tfe_explorer_db` is `false`. | `string` | `null` | no |
+| <a name="input_tfe_explorer_enabled"></a> [tfe\_explorer\_enabled](#input\_tfe\_explorer\_enabled) | Boolean to enable Terraform Enterprise Explorer. Explorer is only supported when `tfe_operational_mode` is `active-active` or `external`. | `bool` | `false` | no |
 | <a name="input_tfe_hairpin_addressing"></a> [tfe\_hairpin\_addressing](#input\_tfe\_hairpin\_addressing) | Boolean to enable hairpin addressing within TFE container networking for loopback prevention with a layer 4 internal load balancer. | `bool` | `true` | no |
 | <a name="input_tfe_http_port"></a> [tfe\_http\_port](#input\_tfe\_http\_port) | HTTP port for TFE application containers to listen on. | `number` | `8080` | no |
 | <a name="input_tfe_https_port"></a> [tfe\_https\_port](#input\_tfe\_https\_port) | HTTPS port for TFE application containers to listen on. | `number` | `8443` | no |
@@ -323,6 +340,7 @@ Please note that there is no official Service Level Agreement (SLA) for support 
 | <a name="output_tfe_database_name"></a> [tfe\_database\_name](#output\_tfe\_database\_name) | Name of TFE database. |
 | <a name="output_tfe_database_password"></a> [tfe\_database\_password](#output\_tfe\_database\_password) | Password of TFE database user. |
 | <a name="output_tfe_database_user"></a> [tfe\_database\_user](#output\_tfe\_database\_user) | Username of TFE database. |
+| <a name="output_tfe_explorer_database_warning"></a> [tfe\_explorer\_database\_warning](#output\_tfe\_explorer\_database\_warning) | Warning emitted when Explorer is enabled but still reuses the primary TFE database instead of a dedicated Explorer database. |
 | <a name="output_tfe_gcs_bucket_location"></a> [tfe\_gcs\_bucket\_location](#output\_tfe\_gcs\_bucket\_location) | Location of TFE GCS bucket. |
 | <a name="output_tfe_lb_ip_address"></a> [tfe\_lb\_ip\_address](#output\_tfe\_lb\_ip\_address) | IP Address of TFE front end load balancer (forwarding rule). |
 | <a name="output_tfe_load_balancing_scheme"></a> [tfe\_load\_balancing\_scheme](#output\_tfe\_load\_balancing\_scheme) | Load balancing scheme of TFE front end load balancer (forwarding rule). |

--- a/compute.tf
+++ b/compute.tf
@@ -20,8 +20,18 @@ locals {
 # Metadata startup script
 #-----------------------------------------------------------------------------------
 locals {
-  tfe_startup_script_tpl = var.custom_tfe_startup_script_template != null ? "${path.cwd}/templates/${var.custom_tfe_startup_script_template}" : "${path.module}/templates/tfe_startup_script.sh.tpl"
-  redis_port             = var.redis_transit_encryption_mode == "SERVER_AUTHENTICATION" ? "6378" : "6379"
+  tfe_startup_script_tpl                  = var.custom_tfe_startup_script_template != null ? "${path.cwd}/templates/${var.custom_tfe_startup_script_template}" : "${path.module}/templates/tfe_startup_script.sh.tpl"
+  redis_port                              = var.redis_transit_encryption_mode == "SERVER_AUTHENTICATION" ? "6378" : "6379"
+  tfe_explorer_iam_database_user          = trimsuffix(google_service_account.tfe.email, ".gserviceaccount.com")
+  tfe_explorer_database_is_module_managed = var.tfe_explorer_enabled && var.create_tfe_explorer_db && var.tfe_explorer_database_host == null && var.tfe_explorer_database_name == null && var.tfe_explorer_database_user == null
+  tfe_explorer_database_uses_tfe_database = var.tfe_explorer_enabled && !local.tfe_explorer_database_is_module_managed && var.tfe_explorer_database_host == null && var.tfe_explorer_database_name == null && var.tfe_explorer_database_user == null
+  tfe_explorer_managed_database_name      = coalesce(var.tfe_explorer_database_name, var.tfe_database_name)
+  tfe_explorer_managed_database_user      = var.tfe_explorer_database_auth_use_gcp_iam ? local.tfe_explorer_iam_database_user : coalesce(var.tfe_explorer_database_user, var.tfe_database_user)
+  tfe_explorer_database_host              = !var.tfe_explorer_enabled ? "" : coalesce(var.tfe_explorer_database_host, local.tfe_explorer_database_is_module_managed ? "${google_sql_database_instance.tfe_explorer[0].private_ip_address}:5432" : null, "${google_sql_database_instance.tfe.private_ip_address}:5432")
+  tfe_explorer_database_name              = !var.tfe_explorer_enabled ? "" : coalesce(var.tfe_explorer_database_name, local.tfe_explorer_database_is_module_managed ? local.tfe_explorer_managed_database_name : null, var.tfe_database_name)
+  tfe_explorer_database_user              = !var.tfe_explorer_enabled ? "" : coalesce(var.tfe_explorer_database_user, local.tfe_explorer_database_is_module_managed ? local.tfe_explorer_managed_database_user : null, local.tfe_explorer_database_uses_tfe_database && var.tfe_explorer_database_auth_use_gcp_iam ? local.tfe_explorer_iam_database_user : var.tfe_database_user)
+  tfe_explorer_database_password          = !var.tfe_explorer_enabled || var.tfe_explorer_database_auth_use_gcp_iam ? "" : (var.tfe_explorer_database_password_secret_id != null ? data.google_secret_manager_secret_version.tfe_explorer_database_password[0].secret_data : data.google_secret_manager_secret_version.tfe_database_password.secret_data)
+  tfe_explorer_database_parameters        = !var.tfe_explorer_enabled ? "" : coalesce(var.tfe_explorer_database_parameters, var.tfe_database_parameters)
 
   startup_script_args = {
     # Bootstrap
@@ -55,11 +65,18 @@ locals {
     tfe_https_port                = var.tfe_https_port
 
     # Database settings
-    tfe_database_host       = "${google_sql_database_instance.tfe.private_ip_address}:5432"
-    tfe_database_name       = var.tfe_database_name
-    tfe_database_user       = var.tfe_database_user
-    tfe_database_password   = data.google_secret_manager_secret_version.tfe_database_password.secret_data
-    tfe_database_parameters = var.tfe_database_parameters
+    tfe_database_host                      = "${google_sql_database_instance.tfe.private_ip_address}:5432"
+    tfe_database_name                      = var.tfe_database_name
+    tfe_database_user                      = var.tfe_database_user
+    tfe_database_password                  = data.google_secret_manager_secret_version.tfe_database_password.secret_data
+    tfe_database_parameters                = var.tfe_database_parameters
+    tfe_explorer_enabled                   = var.tfe_explorer_enabled
+    tfe_explorer_database_host             = local.tfe_explorer_database_host
+    tfe_explorer_database_name             = local.tfe_explorer_database_name
+    tfe_explorer_database_user             = local.tfe_explorer_database_user
+    tfe_explorer_database_password         = local.tfe_explorer_database_password
+    tfe_explorer_database_parameters       = local.tfe_explorer_database_parameters
+    tfe_explorer_database_auth_use_gcp_iam = var.tfe_explorer_enabled ? var.tfe_explorer_database_auth_use_gcp_iam : false
 
     # Object storage settings
     tfe_object_storage_type               = "google"

--- a/docs/deployment-customizations.md
+++ b/docs/deployment-customizations.md
@@ -31,6 +31,41 @@ lb_static_ip_address = "10.0.1.20" # optional
 lb_is_internal = false
 ```
 
+## Explorer
+
+Terraform Enterprise Explorer can be enabled with the following module inputs:
+
+```hcl
+tfe_explorer_enabled = true
+create_tfe_explorer_db = true
+```
+
+HashiCorp recommends a dedicated PostgreSQL database for Explorer. When `tfe_explorer_enabled` is `true`, this module creates and uses a dedicated Cloud SQL for PostgreSQL instance for Explorer by default.
+
+To use your own dedicated Explorer database instead, set `create_tfe_explorer_db = false` and provide the following inputs:
+
+```hcl
+tfe_explorer_enabled                     = true
+create_tfe_explorer_db                   = false
+tfe_explorer_database_host               = "explorer-db.example.internal:5432"
+tfe_explorer_database_name               = "tfe_explorer"
+tfe_explorer_database_user               = "tfe_explorer"
+tfe_explorer_database_password_secret_id = "tfe-explorer-database-password"
+tfe_explorer_database_parameters         = "sslmode=require"
+```
+
+If Explorer is enabled, `create_tfe_explorer_db = false`, and you leave all `tfe_explorer_database_*` inputs as `null`, the module reuses the primary TFE database connection details and emits the `tfe_explorer_database_warning` output. This fallback is intended for non-production use only.
+
+### Explorer database IAM authentication
+
+To use Google Cloud IAM database authentication for Explorer on a module-managed or shared module-managed Cloud SQL instance, set:
+
+```hcl
+tfe_explorer_database_auth_use_gcp_iam = true
+```
+
+When this is enabled, the module turns on Cloud SQL IAM database authentication, grants the TFE service account the `roles/cloudsql.instanceUser` role, and creates the matching Cloud SQL IAM database user automatically. For externally managed Explorer databases, you must configure the corresponding IAM authentication settings and database user outside this module.
+
 ## DNS
 
 This module supports optionally creating a DNS record within your existing Google Cloud DNS managed zone for your TFE FQDN.

--- a/docs/tfe-config-settings.md
+++ b/docs/tfe-config-settings.md
@@ -54,3 +54,11 @@ Some settings from the configuration reference are intentionally not exposed as 
 2. The setting is hard coded based on the module's design and is not intended to be configurable by users.
 
 If you feel like a setting from the configuration reference is missing from the `variables.tf` of this module, then please file a GitHub issue.
+
+## Explorer configuration
+
+Explorer configuration follows the same pattern. The module computes the final Explorer database settings in `compute.tf`, then renders `TFE_EXPLORER_DATABASE_*` environment variables into both the Docker Compose and Podman manifests.
+
+When `tfe_explorer_enabled` is `true`, the module creates and uses a dedicated Explorer Cloud SQL instance by default. If `create_tfe_explorer_db` is set to `false` and no dedicated Explorer database inputs are provided, the module falls back to the primary TFE database connection values and emits the `tfe_explorer_database_warning` output so that this non-production configuration is visible in Terraform.
+
+When `tfe_explorer_database_auth_use_gcp_iam` is `true` and the Explorer database is module-managed or reuses the module-managed primary Cloud SQL instance, the module enables Cloud SQL IAM database authentication and derives the Explorer database username from the TFE service account.

--- a/examples/docker-ubuntu-internal-nlb/README.md
+++ b/examples/docker-ubuntu-internal-nlb/README.md
@@ -9,3 +9,5 @@
 | Load balancer type          | `nlb` (TCP/Layer 4)          |
 | Load balancer scheme        | `internal` (private)         |
 | Log forwarding destination  | `stackdriver`                |
+
+Explorer is disabled by default in this example. Set `tfe_explorer_enabled = true` to have the module provision a dedicated Explorer Cloud SQL instance automatically, or pass explicit Explorer database settings to use an existing database.

--- a/examples/docker-ubuntu-internal-nlb/main.tf
+++ b/examples/docker-ubuntu-internal-nlb/main.tf
@@ -63,7 +63,15 @@ module "tfe" {
   container_runtime  = var.container_runtime
 
   # --- Database --- #
-  tfe_database_password_secret_id = var.tfe_database_password_secret_id
+  tfe_database_password_secret_id          = var.tfe_database_password_secret_id
+  tfe_explorer_enabled                     = var.tfe_explorer_enabled
+  create_tfe_explorer_db                   = var.create_tfe_explorer_db
+  tfe_explorer_database_host               = var.tfe_explorer_database_host
+  tfe_explorer_database_name               = var.tfe_explorer_database_name
+  tfe_explorer_database_user               = var.tfe_explorer_database_user
+  tfe_explorer_database_password_secret_id = var.tfe_explorer_database_password_secret_id
+  tfe_explorer_database_parameters         = var.tfe_explorer_database_parameters
+  tfe_explorer_database_auth_use_gcp_iam   = var.tfe_explorer_database_auth_use_gcp_iam
 
   # --- Log forwarding (optional) --- #
   tfe_log_forwarding_enabled = var.tfe_log_forwarding_enabled

--- a/examples/docker-ubuntu-internal-nlb/terraform.tfvars.example
+++ b/examples/docker-ubuntu-internal-nlb/terraform.tfvars.example
@@ -39,6 +39,14 @@ container_runtime  = "docker"
 
 # --- Database --- #
 tfe_database_password_secret_id = "<tfe-database-password-secret-name>"
+tfe_explorer_enabled            = false
+create_tfe_explorer_db          = true
+# tfe_explorer_database_password_secret_id = "<tfe-explorer-database-password-secret-name>"
+# tfe_explorer_database_host               = "explorer-db.example.internal:5432"
+# tfe_explorer_database_name               = "tfe_explorer"
+# tfe_explorer_database_user               = "tfe_explorer"
+# tfe_explorer_database_parameters         = "sslmode=require"
+# tfe_explorer_database_auth_use_gcp_iam   = false
 
 # --- Log forwarding (optional) --- #
 tfe_log_forwarding_enabled = <true>

--- a/examples/docker-ubuntu-internal-nlb/variables.tf
+++ b/examples/docker-ubuntu-internal-nlb/variables.tf
@@ -425,6 +425,54 @@ variable "tfe_database_user" {
   default     = "tfe"
 }
 
+variable "tfe_explorer_enabled" {
+  type        = bool
+  description = "Boolean to enable Terraform Enterprise Explorer."
+  default     = false
+}
+
+variable "create_tfe_explorer_db" {
+  type        = bool
+  description = "Boolean to create a dedicated Explorer Cloud SQL instance when Explorer is enabled and no explicit Explorer database connection values are provided."
+  default     = true
+}
+
+variable "tfe_explorer_database_host" {
+  type        = string
+  description = "Explorer PostgreSQL host in `HOST[:PORT]` format when using an existing Explorer database."
+  default     = null
+}
+
+variable "tfe_explorer_database_name" {
+  type        = string
+  description = "Explorer PostgreSQL database name when using an existing Explorer database."
+  default     = null
+}
+
+variable "tfe_explorer_database_user" {
+  type        = string
+  description = "Explorer PostgreSQL username when using an existing Explorer database."
+  default     = null
+}
+
+variable "tfe_explorer_database_password_secret_id" {
+  type        = string
+  description = "Name of Explorer PostgreSQL database password secret in Google Secret Manager."
+  default     = null
+}
+
+variable "tfe_explorer_database_parameters" {
+  type        = string
+  description = "Additional parameters to pass into the Explorer database settings for the PostgreSQL connection URI."
+  default     = null
+}
+
+variable "tfe_explorer_database_auth_use_gcp_iam" {
+  type        = bool
+  description = "Boolean to use Google Cloud IAM database authentication for Explorer."
+  default     = false
+}
+
 variable "tfe_database_parameters" {
   type        = string
   description = "Additional parameters to pass into the TFE database settings for the PostgreSQL connection URI."

--- a/examples/podman-rhel-internal-nlb/README.md
+++ b/examples/podman-rhel-internal-nlb/README.md
@@ -9,3 +9,5 @@
 | Load balancer type          | `nlb` (TCP/Layer 4)          |
 | Load balancer scheme        | `internal` (private)         |
 | Log forwarding destination  | `stackdriver`                |
+
+Explorer is disabled by default in this example. Set `tfe_explorer_enabled = true` to have the module provision a dedicated Explorer Cloud SQL instance automatically, or pass explicit Explorer database settings to use an existing database.

--- a/examples/podman-rhel-internal-nlb/main.tf
+++ b/examples/podman-rhel-internal-nlb/main.tf
@@ -63,7 +63,15 @@ module "tfe" {
   container_runtime  = var.container_runtime
 
   # --- Database --- #
-  tfe_database_password_secret_id = var.tfe_database_password_secret_id
+  tfe_database_password_secret_id          = var.tfe_database_password_secret_id
+  tfe_explorer_enabled                     = var.tfe_explorer_enabled
+  create_tfe_explorer_db                   = var.create_tfe_explorer_db
+  tfe_explorer_database_host               = var.tfe_explorer_database_host
+  tfe_explorer_database_name               = var.tfe_explorer_database_name
+  tfe_explorer_database_user               = var.tfe_explorer_database_user
+  tfe_explorer_database_password_secret_id = var.tfe_explorer_database_password_secret_id
+  tfe_explorer_database_parameters         = var.tfe_explorer_database_parameters
+  tfe_explorer_database_auth_use_gcp_iam   = var.tfe_explorer_database_auth_use_gcp_iam
 
   # --- Log forwarding (optional) --- #
   tfe_log_forwarding_enabled = var.tfe_log_forwarding_enabled

--- a/examples/podman-rhel-internal-nlb/terraform.tfvars.example
+++ b/examples/podman-rhel-internal-nlb/terraform.tfvars.example
@@ -39,6 +39,14 @@ container_runtime  = "podman"
 
 # --- Database --- #
 tfe_database_password_secret_id = "<tfe-database-password-secret-name>"
+tfe_explorer_enabled            = false
+create_tfe_explorer_db          = true
+# tfe_explorer_database_password_secret_id = "<tfe-explorer-database-password-secret-name>"
+# tfe_explorer_database_host               = "explorer-db.example.internal:5432"
+# tfe_explorer_database_name               = "tfe_explorer"
+# tfe_explorer_database_user               = "tfe_explorer"
+# tfe_explorer_database_parameters         = "sslmode=require"
+# tfe_explorer_database_auth_use_gcp_iam   = false
 
 # --- Log forwarding (optional) --- #
 tfe_log_forwarding_enabled = <true>

--- a/examples/podman-rhel-internal-nlb/variables.tf
+++ b/examples/podman-rhel-internal-nlb/variables.tf
@@ -425,6 +425,54 @@ variable "tfe_database_user" {
   default     = "tfe"
 }
 
+variable "tfe_explorer_enabled" {
+  type        = bool
+  description = "Boolean to enable Terraform Enterprise Explorer."
+  default     = false
+}
+
+variable "create_tfe_explorer_db" {
+  type        = bool
+  description = "Boolean to create a dedicated Explorer Cloud SQL instance when Explorer is enabled and no explicit Explorer database connection values are provided."
+  default     = true
+}
+
+variable "tfe_explorer_database_host" {
+  type        = string
+  description = "Explorer PostgreSQL host in `HOST[:PORT]` format when using an existing Explorer database."
+  default     = null
+}
+
+variable "tfe_explorer_database_name" {
+  type        = string
+  description = "Explorer PostgreSQL database name when using an existing Explorer database."
+  default     = null
+}
+
+variable "tfe_explorer_database_user" {
+  type        = string
+  description = "Explorer PostgreSQL username when using an existing Explorer database."
+  default     = null
+}
+
+variable "tfe_explorer_database_password_secret_id" {
+  type        = string
+  description = "Name of Explorer PostgreSQL database password secret in Google Secret Manager."
+  default     = null
+}
+
+variable "tfe_explorer_database_parameters" {
+  type        = string
+  description = "Additional parameters to pass into the Explorer database settings for the PostgreSQL connection URI."
+  default     = null
+}
+
+variable "tfe_explorer_database_auth_use_gcp_iam" {
+  type        = bool
+  description = "Boolean to use Google Cloud IAM database authentication for Explorer."
+  default     = false
+}
+
 variable "tfe_database_parameters" {
   type        = string
   description = "Additional parameters to pass into the TFE database settings for the PostgreSQL connection URI."

--- a/iam.tf
+++ b/iam.tf
@@ -66,6 +66,22 @@ resource "google_secret_manager_secret_iam_member" "tfe_ca_bundle" {
   member    = "serviceAccount:${google_service_account.tfe.email}"
 }
 
+resource "google_secret_manager_secret_iam_member" "tfe_explorer_database_password" {
+  count = var.tfe_explorer_database_password_secret_id != null ? 1 : 0
+
+  secret_id = var.tfe_explorer_database_password_secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.tfe.email}"
+}
+
+resource "google_project_iam_member" "tfe_cloudsql_instance_user" {
+  count = var.tfe_explorer_enabled && var.tfe_explorer_database_auth_use_gcp_iam && var.tfe_explorer_database_host == null ? 1 : 0
+
+  project = data.google_client_config.current.project
+  role    = "roles/cloudsql.instanceUser"
+  member  = "serviceAccount:${google_service_account.tfe.email}"
+}
+
 resource "google_project_iam_member" "tfe_logging_stackdriver" {
   count = var.tfe_log_forwarding_enabled && var.log_fwd_destination_type == "stackdriver" ? 1 : 0
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -19,6 +19,11 @@ output "tfe_create_initial_admin_user_url" {
   description = "URL to create TFE initial admin user."
 }
 
+output "tfe_explorer_database_warning" {
+  value       = local.tfe_explorer_database_uses_tfe_database ? "WARNING: Terraform Enterprise Explorer is enabled and reuses the primary TFE Cloud SQL database because `create_tfe_explorer_db` is `false` and no dedicated Explorer database was provided. Use a dedicated Explorer database in production." : null
+  description = "Warning emitted when Explorer is enabled but still reuses the primary TFE database instead of a dedicated Explorer database."
+}
+
 #------------------------------------------------------------------------------
 # Load balancer
 #------------------------------------------------------------------------------
@@ -102,4 +107,3 @@ output "tfe_redis_use_tls" {
   value       = var.tfe_operational_mode == "active-active" ? local.startup_script_args["tfe_redis_use_tls"] : null
   description = "Whether TFE should use TLS to connect to Redis instance."
 }
-

--- a/postgresql.tf
+++ b/postgresql.tf
@@ -8,6 +8,12 @@ data "google_secret_manager_secret_version" "tfe_database_password" {
   secret = var.tfe_database_password_secret_id
 }
 
+data "google_secret_manager_secret_version" "tfe_explorer_database_password" {
+  count = var.tfe_explorer_database_password_secret_id != null ? 1 : 0
+
+  secret = var.tfe_explorer_database_password_secret_id
+}
+
 #------------------------------------------------------------------------------
 # Cloud SQL for PostgreSQL
 #------------------------------------------------------------------------------
@@ -32,6 +38,70 @@ resource "google_sql_database_instance" "tfe" {
       ipv4_enabled    = false
       private_network = data.google_compute_network.vpc.self_link
       ssl_mode        = var.postgres_ssl_mode
+    }
+
+    dynamic "database_flags" {
+      for_each = var.tfe_explorer_enabled && var.tfe_explorer_database_auth_use_gcp_iam && local.tfe_explorer_database_uses_tfe_database ? [1] : []
+
+      content {
+        name  = "cloudsql.iam_authentication"
+        value = "on"
+      }
+    }
+
+    backup_configuration {
+      enabled    = true
+      start_time = var.postgres_backup_start_time
+    }
+
+    maintenance_window {
+      day          = var.postgres_maintenance_window.day
+      hour         = var.postgres_maintenance_window.hour
+      update_track = var.postgres_maintenance_window.update_track
+    }
+
+    insights_config {
+      query_insights_enabled  = var.postgres_insights_config.query_insights_enabled
+      query_plans_per_minute  = var.postgres_insights_config.query_plans_per_minute
+      query_string_length     = var.postgres_insights_config.query_string_length
+      record_application_tags = var.postgres_insights_config.record_application_tags
+      record_client_address   = var.postgres_insights_config.record_client_address
+    }
+
+    user_labels = var.common_labels
+  }
+
+  depends_on = [google_kms_crypto_key_iam_member.postgres_cmek]
+}
+
+resource "google_sql_database_instance" "tfe_explorer" {
+  count = local.tfe_explorer_database_is_module_managed ? 1 : 0
+
+  name                = "${var.friendly_name_prefix}-tfe-explorer-postgres-${random_id.postgres_instance_suffix.hex}"
+  database_version    = var.postgres_version
+  encryption_key_name = var.postgres_kms_cmek_name != null ? data.google_kms_crypto_key.postgres_cmek[0].id : null
+  deletion_protection = var.postgres_deletetion_protection
+
+  settings {
+    availability_type = var.postgres_availability_type
+    tier              = var.postgres_machine_type
+    disk_type         = "PD_SSD"
+    disk_size         = var.postgres_disk_size
+    disk_autoresize   = true
+
+    ip_configuration {
+      ipv4_enabled    = false
+      private_network = data.google_compute_network.vpc.self_link
+      ssl_mode        = var.postgres_ssl_mode
+    }
+
+    dynamic "database_flags" {
+      for_each = var.tfe_explorer_database_auth_use_gcp_iam ? [1] : []
+
+      content {
+        name  = "cloudsql.iam_authentication"
+        value = "on"
+      }
     }
 
     backup_configuration {
@@ -68,6 +138,37 @@ resource "google_sql_user" "tfe" {
   name     = var.tfe_database_user
   instance = google_sql_database_instance.tfe.name
   password = data.google_secret_manager_secret_version.tfe_database_password.secret_data
+}
+
+resource "google_sql_database" "tfe_explorer" {
+  count = local.tfe_explorer_database_is_module_managed ? 1 : 0
+
+  name     = local.tfe_explorer_managed_database_name
+  instance = google_sql_database_instance.tfe_explorer[0].name
+}
+
+resource "google_sql_user" "tfe_explorer" {
+  count = local.tfe_explorer_database_is_module_managed && !var.tfe_explorer_database_auth_use_gcp_iam ? 1 : 0
+
+  name     = local.tfe_explorer_managed_database_user
+  instance = google_sql_database_instance.tfe_explorer[0].name
+  password = var.tfe_explorer_database_password_secret_id != null ? data.google_secret_manager_secret_version.tfe_explorer_database_password[0].secret_data : data.google_secret_manager_secret_version.tfe_database_password.secret_data
+}
+
+resource "google_sql_user" "tfe_explorer_iam" {
+  count = var.tfe_explorer_enabled && var.tfe_explorer_database_auth_use_gcp_iam && local.tfe_explorer_database_is_module_managed ? 1 : 0
+
+  name     = local.tfe_explorer_iam_database_user
+  instance = google_sql_database_instance.tfe_explorer[0].name
+  type     = "CLOUD_IAM_SERVICE_ACCOUNT"
+}
+
+resource "google_sql_user" "tfe_primary_explorer_iam" {
+  count = var.tfe_explorer_enabled && var.tfe_explorer_database_auth_use_gcp_iam && local.tfe_explorer_database_uses_tfe_database ? 1 : 0
+
+  name     = local.tfe_explorer_iam_database_user
+  instance = google_sql_database_instance.tfe.name
+  type     = "CLOUD_IAM_SERVICE_ACCOUNT"
 }
 
 #------------------------------------------------------------------------------

--- a/templates/tfe_startup_script.sh.tpl
+++ b/templates/tfe_startup_script.sh.tpl
@@ -201,6 +201,16 @@ services:
       TFE_DATABASE_USER: ${tfe_database_user}
       TFE_DATABASE_PASSWORD: ${tfe_database_password}
       TFE_DATABASE_PARAMETERS: ${tfe_database_parameters}
+%{ if tfe_explorer_enabled ~}
+      TFE_EXPLORER_DATABASE_HOST: ${tfe_explorer_database_host}
+      TFE_EXPLORER_DATABASE_NAME: ${tfe_explorer_database_name}
+      TFE_EXPLORER_DATABASE_USER: ${tfe_explorer_database_user}
+      TFE_EXPLORER_DATABASE_PARAMETERS: ${tfe_explorer_database_parameters}
+      TFE_EXPLORER_DATABASE_AUTH_USE_GCP_IAM: ${tfe_explorer_database_auth_use_gcp_iam}
+%{ if !tfe_explorer_database_auth_use_gcp_iam ~}
+      TFE_EXPLORER_DATABASE_PASSWORD: ${tfe_explorer_database_password}
+%{ endif ~}
+%{ endif ~}
       
       # Object storage settings
       TFE_OBJECT_STORAGE_TYPE: ${tfe_object_storage_type}
@@ -360,6 +370,22 @@ spec:
       value: ${tfe_database_password}
     - name: "TFE_DATABASE_PARAMETERS"
       value: ${tfe_database_parameters}
+%{ if tfe_explorer_enabled ~}
+    - name: "TFE_EXPLORER_DATABASE_HOST"
+      value: ${tfe_explorer_database_host}
+    - name: "TFE_EXPLORER_DATABASE_NAME"
+      value: ${tfe_explorer_database_name}
+    - name: "TFE_EXPLORER_DATABASE_USER"
+      value: ${tfe_explorer_database_user}
+    - name: "TFE_EXPLORER_DATABASE_PARAMETERS"
+      value: ${tfe_explorer_database_parameters}
+    - name: "TFE_EXPLORER_DATABASE_AUTH_USE_GCP_IAM"
+      value: ${tfe_explorer_database_auth_use_gcp_iam}
+%{ if !tfe_explorer_database_auth_use_gcp_iam ~}
+    - name: "TFE_EXPLORER_DATABASE_PASSWORD"
+      value: ${tfe_explorer_database_password}
+%{ endif ~}
+%{ endif ~}
 
     # Object storage settings
     - name: "TFE_OBJECT_STORAGE_TYPE"

--- a/variables.tf
+++ b/variables.tf
@@ -176,6 +176,17 @@ variable "tfe_run_pipeline_image" {
   default     = null
 }
 
+variable "tfe_explorer_enabled" {
+  type        = bool
+  description = "Boolean to enable Terraform Enterprise Explorer. Explorer is only supported when `tfe_operational_mode` is `active-active` or `external`."
+  default     = false
+
+  validation {
+    condition     = !var.tfe_explorer_enabled || contains(["active-active", "external"], var.tfe_operational_mode)
+    error_message = "Explorer is only supported when `tfe_operational_mode` is `active-active` or `external`."
+  }
+}
+
 variable "tfe_metrics_enable" {
   type        = bool
   description = "Boolean to enable TFE metrics collection endpoints."
@@ -429,6 +440,70 @@ variable "tfe_database_parameters" {
   type        = string
   description = "Additional parameters to pass into the TFE database settings for the PostgreSQL connection URI."
   default     = "sslmode=require"
+}
+
+variable "create_tfe_explorer_db" {
+  type        = bool
+  description = "Boolean to create and use a module-managed dedicated Cloud SQL for PostgreSQL instance for Explorer when `tfe_explorer_enabled` is `true` and no explicit Explorer database host, name, and user values are provided."
+  default     = true
+}
+
+variable "tfe_explorer_database_host" {
+  type        = string
+  description = "PostgreSQL server for Explorer in `HOST[:PORT]` format. Leave as `null` to have the module create and use a dedicated Explorer Cloud SQL instance when `create_tfe_explorer_db` is `true`, or reuse the primary TFE Cloud SQL instance when `create_tfe_explorer_db` is `false`."
+  default     = null
+
+  validation {
+    condition = !var.tfe_explorer_enabled || (
+      (var.tfe_explorer_database_host == null && var.tfe_explorer_database_name == null && var.tfe_explorer_database_user == null) ||
+      (var.tfe_explorer_database_host != null && var.tfe_explorer_database_name != null && var.tfe_explorer_database_user != null)
+    )
+    error_message = "Values of `tfe_explorer_database_host`, `tfe_explorer_database_name`, and `tfe_explorer_database_user` must either all be set or all be `null` when `tfe_explorer_enabled` is `true`."
+  }
+}
+
+variable "tfe_explorer_database_name" {
+  type        = string
+  description = "Name of the PostgreSQL database used by Explorer. Leave as `null` to have the module use the Explorer database name it manages when `create_tfe_explorer_db` is `true`, or reuse the primary TFE database name when `create_tfe_explorer_db` is `false`."
+  default     = null
+}
+
+variable "tfe_explorer_database_user" {
+  type        = string
+  description = "PostgreSQL username used by Explorer. Leave as `null` to have the module use the Explorer database user it manages when `create_tfe_explorer_db` is `true`, or reuse the primary TFE database user when `create_tfe_explorer_db` is `false`."
+  default     = null
+}
+
+variable "tfe_explorer_database_password_secret_id" {
+  type        = string
+  description = "Name of Google Secret Manager secret for the Explorer database password. Leave as `null` when `tfe_explorer_database_auth_use_gcp_iam` is `true` or to reuse the primary TFE database password for the module-managed Explorer database or shared primary-database fallback."
+  default     = null
+
+  validation {
+    condition = !var.tfe_explorer_enabled || var.tfe_explorer_database_auth_use_gcp_iam || (
+      var.tfe_explorer_database_host == null
+      ? (var.create_tfe_explorer_db || var.tfe_explorer_database_password_secret_id == null)
+      : var.tfe_explorer_database_password_secret_id != null
+    )
+    error_message = "Value must be set when `tfe_explorer_enabled` is `true`, `tfe_explorer_database_auth_use_gcp_iam` is `false`, and an external Explorer database host is specified. When `create_tfe_explorer_db` is `false` and no external Explorer database host is set, leave this value as `null` so Explorer reuses the primary TFE database password."
+  }
+}
+
+variable "tfe_explorer_database_parameters" {
+  type        = string
+  description = "PostgreSQL server parameters for the Explorer connection URI. Leave as `null` to reuse `tfe_database_parameters`."
+  default     = null
+}
+
+variable "tfe_explorer_database_auth_use_gcp_iam" {
+  type        = bool
+  description = "Boolean to use Google Cloud IAM database authentication for Explorer."
+  default     = false
+
+  validation {
+    condition     = !(var.tfe_explorer_database_auth_use_gcp_iam && var.tfe_explorer_database_host == null && var.tfe_explorer_database_user != null)
+    error_message = "Leave `tfe_explorer_database_user` as `null` when `tfe_explorer_database_auth_use_gcp_iam` is `true` and the module is managing or reusing the Cloud SQL instance so it can derive the IAM database user from the TFE service account."
+  }
 }
 
 variable "postgres_version" {


### PR DESCRIPTION
## Summary
Ports the Explorer-focused portion of AWS pull request #47 into the Google HVD module.

This PR adds Terraform Enterprise Explorer configuration support, including dedicated database handling, shared-primary fallback behavior for non-production use, optional Cloud SQL IAM database authentication for module-managed paths, and the corresponding docs/example updates.

## Upstream Mapping
- AWS #47: add Terraform Enterprise Explorer support
- Excluded AWS-specific work: existing EC2 instance profile support does not translate directly to GCP and is not included here

## Changes Made
- add `tfe_explorer_enabled` and related Explorer database inputs
- create a dedicated Cloud SQL for PostgreSQL instance for Explorer by default when the module manages the Explorer database
- support falling back to the primary TFE database connection values when `create_tfe_explorer_db = false` and no dedicated Explorer database is provided
- emit `tfe_explorer_database_warning` when Explorer reuses the primary TFE database
- add optional `tfe_explorer_database_auth_use_gcp_iam` support for module-managed or shared module-managed Cloud SQL paths
- grant the TFE service account `roles/cloudsql.instanceUser` and create matching Cloud SQL IAM users when IAM auth is enabled on module-managed paths
- render `TFE_EXPLORER_DATABASE_*` environment variables into both Docker Compose and Podman manifests
- update example module calls, example variables, example tfvars, and example READMEs
- regenerate the module README and update deployment/configuration docs

## Google-Specific Notes
The AWS implementation provisions a dedicated Aurora database path and optionally reuses an EC2 instance profile for IAM database authentication. In the Google module, the closest equivalent is a dedicated Cloud SQL instance for module-managed Explorer plus optional Cloud SQL IAM database authentication using the TFE VM service account.

For externally managed Explorer databases, this PR passes through the Explorer connection inputs but leaves any required external IAM authentication setup to the caller.

## Release and Documentation Context
- TFE 1.0.1 introduced Explorer beta
- Explorer requires `external` or `active-active` mode
- HashiCorp recommends a dedicated Explorer database, with backfill progress visible through `/api/v2/admin/explorer-backfill-status`

## Validation
- run `task terraform-docs`
- run `task test`

## Follow-on Work
Secondary hostname support will be delivered in a separate Google PR to match the requested work split.