### PR TITLE
feat: add secondary hostname support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Terraform module aligned with HashiCorp Validated Designs (HVD) to deploy Terraf
   - (Optional) Load balancer subnet (can be the same as VM subnet if desired; only used when `lb_is_internal` is `true`)
   - Private Service Access (PSA) configured in VPC network for service `servicenetworking.googleapis.com` (refer to the [prereqs reference](./docs/prereqs.md#private-service-access-psa) for more details)
 - Chosen fully qualified domain name (FQDN) for your TFE instance (_e.g._ `tfe.gcp.example.com`)
+- (Optional) Secondary hostname for public callbacks such as OIDC, VCS webhooks, and run tasks (_e.g._ `tfe-callbacks.gcp.example.com`)
 - (Optional) Google Cloud DNS zone for optional TFE DNS record creation
 
 #### Firewall rules
@@ -44,6 +45,7 @@ The following _bootstrap_ secrets stored in Google Secret Manager in order to bo
 - **TFE TLS certificate** - certificate file in PEM format, base64-encoded into a string, and stored as a secret
 - **TFE TLS certificate private key** - private key file in PEM format, base64-encoded into a string, and stored as a secret
 - **TFE TLS CA bundle** - Ca bundle file in PEM format, base64-encoded into a string, and stored as a secret
+- **Secondary TFE TLS certificate / private key / CA bundle** - optional additional PEM assets, base64-encoded into strings, used when `tfe_hostname_secondary` is enabled
 
 Refer to the [prereqs reference](./docs/prereqs.md#tfe-bootstrap-secrets) for more details on how the secrets should be created and stored.
 
@@ -148,7 +150,7 @@ Please note that there is no official Service Level Agreement (SLA) for support 
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | ~> 6.6 |
 | <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | ~> 6.6 |
@@ -157,7 +159,7 @@ Please note that there is no official Service Level Agreement (SLA) for support 
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_google"></a> [google](#provider\_google) | ~> 6.6 |
 | <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | ~> 6.6 |
 | <a name="provider_random"></a> [random](#provider\_random) | ~> 3.6 |
@@ -165,24 +167,30 @@ Please note that there is no official Service Level Agreement (SLA) for support 
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [google-beta_google_project_service_identity.gcp_project_cloud_sql_sa](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/google_project_service_identity) | resource |
 | [google_compute_address.tfe_frontend_lb](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_address) | resource |
+| [google_compute_address.tfe_secondary_frontend_lb](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_address) | resource |
 | [google_compute_firewall.vm_allow_ingress_ssh_from_cidr](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall) | resource |
 | [google_compute_firewall.vm_allow_ingress_ssh_from_iap](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall) | resource |
 | [google_compute_firewall.vm_allow_lb_health_checks_443](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall) | resource |
 | [google_compute_firewall.vm_allow_tfe_443](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall) | resource |
 | [google_compute_firewall.vm_allow_tfe_admin_console](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall) | resource |
 | [google_compute_firewall.vm_allow_tfe_metrics_from_cidr](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall) | resource |
+| [google_compute_firewall.vm_allow_tfe_secondary_443](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall) | resource |
 | [google_compute_firewall.vm_tfe_self_allow](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall) | resource |
 | [google_compute_forwarding_rule.tfe_admin_console_lb](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_forwarding_rule) | resource |
 | [google_compute_forwarding_rule.tfe_frontend_lb](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_forwarding_rule) | resource |
+| [google_compute_forwarding_rule.tfe_secondary_frontend_lb](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_forwarding_rule) | resource |
 | [google_compute_health_check.tfe_auto_healing](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_health_check) | resource |
 | [google_compute_instance_template.tfe](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance_template) | resource |
 | [google_compute_region_backend_service.tfe_backend_lb](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_region_backend_service) | resource |
+| [google_compute_region_backend_service.tfe_secondary_backend_lb](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_region_backend_service) | resource |
 | [google_compute_region_health_check.tfe_backend_lb](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_region_health_check) | resource |
+| [google_compute_region_health_check.tfe_secondary_backend_lb](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_region_health_check) | resource |
 | [google_compute_region_instance_group_manager.tfe](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_region_instance_group_manager) | resource |
 | [google_dns_record_set.tfe](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/dns_record_set) | resource |
+| [google_dns_record_set.tfe_secondary](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/dns_record_set) | resource |
 | [google_kms_crypto_key_iam_member.gcp_project_gcs_sa_cmek](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/kms_crypto_key_iam_member) | resource |
 | [google_kms_crypto_key_iam_member.gcp_project_redis_sa_cmek](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/kms_crypto_key_iam_member) | resource |
 | [google_kms_crypto_key_iam_member.postgres_cmek](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/kms_crypto_key_iam_member) | resource |
@@ -193,6 +201,9 @@ Please note that there is no official Service Level Agreement (SLA) for support 
 | [google_secret_manager_secret_iam_member.tfe_encryption_password](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_iam_member) | resource |
 | [google_secret_manager_secret_iam_member.tfe_license](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_iam_member) | resource |
 | [google_secret_manager_secret_iam_member.tfe_privkey](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_iam_member) | resource |
+| [google_secret_manager_secret_iam_member.tfe_secondary_ca_bundle](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_iam_member) | resource |
+| [google_secret_manager_secret_iam_member.tfe_secondary_cert](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_iam_member) | resource |
+| [google_secret_manager_secret_iam_member.tfe_secondary_privkey](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_iam_member) | resource |
 | [google_service_account.tfe](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
 | [google_service_account_key.tfe](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_key) | resource |
 | [google_sql_database.tfe](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_database) | resource |
@@ -210,6 +221,7 @@ Please note that there is no official Service Level Agreement (SLA) for support 
 | [google_compute_subnetwork.vm_subnet](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_subnetwork) | data source |
 | [google_compute_zones.up](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_zones) | data source |
 | [google_dns_managed_zone.tfe](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/dns_managed_zone) | data source |
+| [google_dns_managed_zone.tfe_secondary](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/dns_managed_zone) | data source |
 | [google_kms_crypto_key.gcs_cmek](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/kms_crypto_key) | data source |
 | [google_kms_crypto_key.postgres_cmek](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/kms_crypto_key) | data source |
 | [google_kms_crypto_key.redis_cmek](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/kms_crypto_key) | data source |
@@ -223,7 +235,7 @@ Please note that there is no official Service Level Agreement (SLA) for support 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_friendly_name_prefix"></a> [friendly\_name\_prefix](#input\_friendly\_name\_prefix) | Friendly name prefix used for uniquely naming all GCP resources for this deployment. Most commonly set to either an environment (e.g. 'sandbox', 'prod'), a team name, or a project name. | `string` | n/a | yes |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | ID of GCP project to deploy TFE in. | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | GCP region (location) to deploy TFE in. | `string` | n/a | yes |
@@ -240,11 +252,14 @@ Please note that there is no official Service Level Agreement (SLA) for support 
 | <a name="input_cidr_allow_ingress_tfe_443"></a> [cidr\_allow\_ingress\_tfe\_443](#input\_cidr\_allow\_ingress\_tfe\_443) | List of CIDR ranges to allow TCP/443 (HTTPS) inbound to TFE load balancer. | `list(string)` | `null` | no |
 | <a name="input_cidr_allow_ingress_tfe_admin_console"></a> [cidr\_allow\_ingress\_tfe\_admin\_console](#input\_cidr\_allow\_ingress\_tfe\_admin\_console) | List of CIDR ranges to allow TCP ingress to the TFE Admin Console port. Required when `tfe_admin_console_disabled` is `false`. | `list(string)` | `null` | no |
 | <a name="input_cidr_allow_ingress_tfe_metrics"></a> [cidr\_allow\_ingress\_tfe\_metrics](#input\_cidr\_allow\_ingress\_tfe\_metrics) | List of CIDR ranges to allow TCP/9090 (HTTP) and TCP/9091 (HTTPS) inbound to TFE metrics collection endpoint. | `list(string)` | `null` | no |
+| <a name="input_cidr_allow_ingress_tfe_secondary_443"></a> [cidr\_allow\_ingress\_tfe\_secondary\_443](#input\_cidr\_allow\_ingress\_tfe\_secondary\_443) | List of CIDR ranges to allow TCP/443 (HTTPS) inbound to the optional secondary public TFE load balancer. | `list(string)` | <pre>[<br/>  "0.0.0.0/0"<br/>]</pre> | no |
 | <a name="input_cidr_allow_ingress_vm_ssh"></a> [cidr\_allow\_ingress\_vm\_ssh](#input\_cidr\_allow\_ingress\_vm\_ssh) | List of CIDR ranges to allow TCP/22 (SSH) inbound to TFE GCE instances. | `list(string)` | `null` | no |
 | <a name="input_cloud_dns_managed_zone_name"></a> [cloud\_dns\_managed\_zone\_name](#input\_cloud\_dns\_managed\_zone\_name) | Name of Google Cloud DNS managed zone to create TFE DNS record in. Required when `create_tfe_cloud_dns_record` is `true`. | `string` | `null` | no |
 | <a name="input_common_labels"></a> [common\_labels](#input\_common\_labels) | Map of common labels to apply to all GCP resources. | `map(string)` | `{}` | no |
 | <a name="input_container_runtime"></a> [container\_runtime](#input\_container\_runtime) | Container runtime to use for TFE deployment. Supported values are `docker` or `podman`. | `string` | `"docker"` | no |
+| <a name="input_create_secondary_tfe_lb"></a> [create\_secondary\_tfe\_lb](#input\_create\_secondary\_tfe\_lb) | Boolean to create a dedicated public external passthrough Network Load Balancer for `tfe_hostname_secondary`. This is only supported when the primary load balancer remains internal (`lb_is_internal = true`). | `bool` | `false` | no |
 | <a name="input_create_tfe_cloud_dns_record"></a> [create\_tfe\_cloud\_dns\_record](#input\_create\_tfe\_cloud\_dns\_record) | Boolean to create Google Cloud DNS record for TFE using the value of `tfe_fqdn` as the record name, resolving to the load balancer IP. `cloud_dns_managed_zone_name` is required when `true`. | `bool` | `false` | no |
+| <a name="input_create_tfe_secondary_cloud_dns_record"></a> [create\_tfe\_secondary\_cloud\_dns\_record](#input\_create\_tfe\_secondary\_cloud\_dns\_record) | Boolean to create a Google Cloud DNS record for `tfe_hostname_secondary`, resolving to the optional secondary public load balancer. `secondary_cloud_dns_managed_zone_name` is required when `true`. | `bool` | `false` | no |
 | <a name="input_custom_fluent_bit_config"></a> [custom\_fluent\_bit\_config](#input\_custom\_fluent\_bit\_config) | Custom Fluent Bit configuration for log forwarding. Only valid when `tfe_log_forwarding_enabled` is `true` and `log_fwd_destination_type` is `custom`. | `string` | `null` | no |
 | <a name="input_custom_tfe_startup_script_template"></a> [custom\_tfe\_startup\_script\_template](#input\_custom\_tfe\_startup\_script\_template) | Name of custom TFE startup script template file. File must exist within a directory named `./templates` within your current working directory. | `string` | `null` | no |
 | <a name="input_docker_version"></a> [docker\_version](#input\_docker\_version) | Version of Docker to install on TFE GCE VM instances. | `string` | `"26.1.4-1"` | no |
@@ -286,6 +301,7 @@ Please note that there is no official Service Level Agreement (SLA) for support 
 | <a name="input_redis_tier"></a> [redis\_tier](#input\_redis\_tier) | The service tier of the Redis instance. Set to `STANDARD_HA` for high availability. | `string` | `"STANDARD_HA"` | no |
 | <a name="input_redis_transit_encryption_mode"></a> [redis\_transit\_encryption\_mode](#input\_redis\_transit\_encryption\_mode) | Determines transit encryption (TLS) mode for Redis instance. | `string` | `"DISABLED"` | no |
 | <a name="input_redis_version"></a> [redis\_version](#input\_redis\_version) | The version of Redis software. | `string` | `"REDIS_7_2"` | no |
+| <a name="input_secondary_cloud_dns_managed_zone_name"></a> [secondary\_cloud\_dns\_managed\_zone\_name](#input\_secondary\_cloud\_dns\_managed\_zone\_name) | Name of Google Cloud DNS managed zone to create the secondary TFE DNS record in. Required when `create_tfe_secondary_cloud_dns_record` is `true`. | `string` | `null` | no |
 | <a name="input_tfe_admin_console_disabled"></a> [tfe\_admin\_console\_disabled](#input\_tfe\_admin\_console\_disabled) | Boolean to disable the TFE Admin Console for advanced troubleshooting and diagnostics. | `bool` | `true` | no |
 | <a name="input_tfe_admin_https_port"></a> [tfe\_admin\_https\_port](#input\_tfe\_admin\_https\_port) | Port the TFE application container listens on for system (admin) API endpoint HTTPS traffic. | `number` | `9443` | no |
 | <a name="input_tfe_capacity_concurrency"></a> [tfe\_capacity\_concurrency](#input\_tfe\_capacity\_concurrency) | Maximum number of concurrent Terraform runs to allow on a TFE node. | `number` | `10` | no |
@@ -295,6 +311,7 @@ Please note that there is no official Service Level Agreement (SLA) for support 
 | <a name="input_tfe_database_parameters"></a> [tfe\_database\_parameters](#input\_tfe\_database\_parameters) | Additional parameters to pass into the TFE database settings for the PostgreSQL connection URI. | `string` | `"sslmode=require"` | no |
 | <a name="input_tfe_database_user"></a> [tfe\_database\_user](#input\_tfe\_database\_user) | Name of TFE PostgreSQL database user to create. | `string` | `"tfe"` | no |
 | <a name="input_tfe_hairpin_addressing"></a> [tfe\_hairpin\_addressing](#input\_tfe\_hairpin\_addressing) | Boolean to enable hairpin addressing within TFE container networking for loopback prevention with a layer 4 internal load balancer. | `bool` | `true` | no |
+| <a name="input_tfe_hostname_secondary"></a> [tfe\_hostname\_secondary](#input\_tfe\_hostname\_secondary) | Optional secondary hostname for TFE. Use this when you need a second externally reachable hostname for OIDC callbacks, VCS webhooks, or run tasks. | `string` | `null` | no |
 | <a name="input_tfe_http_port"></a> [tfe\_http\_port](#input\_tfe\_http\_port) | HTTP port for TFE application containers to listen on. | `number` | `8080` | no |
 | <a name="input_tfe_https_port"></a> [tfe\_https\_port](#input\_tfe\_https\_port) | HTTPS port for TFE application containers to listen on. | `number` | `8443` | no |
 | <a name="input_tfe_iact_subnets"></a> [tfe\_iact\_subnets](#input\_tfe\_iact\_subnets) | Comma-separated list of subnets in CIDR notation that are allowed to retrieve the TFE initial admin creation token via the API or web browser. | `string` | `null` | no |
@@ -310,18 +327,24 @@ Please note that there is no official Service Level Agreement (SLA) for support 
 | <a name="input_tfe_metrics_enable"></a> [tfe\_metrics\_enable](#input\_tfe\_metrics\_enable) | Boolean to enable TFE metrics collection endpoints. | `bool` | `false` | no |
 | <a name="input_tfe_metrics_http_port"></a> [tfe\_metrics\_http\_port](#input\_tfe\_metrics\_http\_port) | HTTP port for TFE metrics collection endpoint to listen on. | `number` | `9090` | no |
 | <a name="input_tfe_metrics_https_port"></a> [tfe\_metrics\_https\_port](#input\_tfe\_metrics\_https\_port) | HTTPS port for TFE metrics collection endpoint to listen on. | `number` | `9091` | no |
+| <a name="input_tfe_oidc_hostname_choice"></a> [tfe\_oidc\_hostname\_choice](#input\_tfe\_oidc\_hostname\_choice) | Hostname choice for OIDC callback URLs. Valid values are `primary` or `secondary`. | `string` | `"primary"` | no |
 | <a name="input_tfe_operational_mode"></a> [tfe\_operational\_mode](#input\_tfe\_operational\_mode) | [Operational mode](https://developer.hashicorp.com/terraform/enterprise/flexible-deployments/install/operation-modes) for TFE. Valid values are `active-active` or `external`. | `string` | `"active-active"` | no |
 | <a name="input_tfe_run_pipeline_docker_network"></a> [tfe\_run\_pipeline\_docker\_network](#input\_tfe\_run\_pipeline\_docker\_network) | Name of Docker network where the containers that execute Terraform runs (agents) will be created. The network must already exist, it will not be created automatically. Leave as `null` to use the default network created during the TFE installation. | `string` | `null` | no |
 | <a name="input_tfe_run_pipeline_image"></a> [tfe\_run\_pipeline\_image](#input\_tfe\_run\_pipeline\_image) | Name of container image used to execute Terraform runs on a TFE node. Leave as `null` to use the default agent that ships with TFE. | `string` | `null` | no |
+| <a name="input_tfe_run_task_hostname_choice"></a> [tfe\_run\_task\_hostname\_choice](#input\_tfe\_run\_task\_hostname\_choice) | Hostname choice for run task callbacks. Valid values are `primary` or `secondary`. | `string` | `"primary"` | no |
+| <a name="input_tfe_tls_ca_bundle_secret_id_secondary"></a> [tfe\_tls\_ca\_bundle\_secret\_id\_secondary](#input\_tfe\_tls\_ca\_bundle\_secret\_id\_secondary) | Name of Google Secret Manager secret for the secondary TFE TLS CA bundle in PEM format. Secret must be stored as a base64-encoded string. Required when `tfe_hostname_secondary` is set. | `string` | `null` | no |
+| <a name="input_tfe_tls_cert_secret_id_secondary"></a> [tfe\_tls\_cert\_secret\_id\_secondary](#input\_tfe\_tls\_cert\_secret\_id\_secondary) | Name of Google Secret Manager secret for the secondary TFE TLS certificate in PEM format. Secret must be stored as a base64-encoded string. Required when `tfe_hostname_secondary` is set. | `string` | `null` | no |
 | <a name="input_tfe_tls_enforce"></a> [tfe\_tls\_enforce](#input\_tfe\_tls\_enforce) | Boolean to enforce TLS, Strict-Transport-Security headers, and secure cookies within TFE. | `bool` | `false` | no |
+| <a name="input_tfe_tls_privkey_secret_id_secondary"></a> [tfe\_tls\_privkey\_secret\_id\_secondary](#input\_tfe\_tls\_privkey\_secret\_id\_secondary) | Name of Google Secret Manager secret for the secondary TFE TLS private key in PEM format. Secret must be stored as a base64-encoded string. Required when `tfe_hostname_secondary` is set. | `string` | `null` | no |
 | <a name="input_tfe_usage_reporting_opt_out"></a> [tfe\_usage\_reporting\_opt\_out](#input\_tfe\_usage\_reporting\_opt\_out) | Boolean to opt out of TFE usage reporting. | `bool` | `false` | no |
 | <a name="input_tfe_vault_disable_mlock"></a> [tfe\_vault\_disable\_mlock](#input\_tfe\_vault\_disable\_mlock) | Boolean to disable mlock for internal (embedded) Vault within TFE. | `bool` | `false` | no |
+| <a name="input_tfe_vcs_hostname_choice"></a> [tfe\_vcs\_hostname\_choice](#input\_tfe\_vcs\_hostname\_choice) | Hostname choice for VCS webhook callback URLs. Valid values are `primary` or `secondary`. | `string` | `"primary"` | no |
 | <a name="input_vpc_network_project_id"></a> [vpc\_network\_project\_id](#input\_vpc\_network\_project\_id) | ID of GCP project where the existing VPC network resides, if it is different than the `project_id` where TFE will be deployed. | `string` | `null` | no |
 
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_tfe_admin_console_url_pattern"></a> [tfe\_admin\_console\_url\_pattern](#output\_tfe\_admin\_console\_url\_pattern) | URL pattern to access the TFE Admin Console. Only applicable when `tfe_admin_console_disabled` is `false`. |
 | <a name="output_tfe_create_initial_admin_user_url"></a> [tfe\_create\_initial\_admin\_user\_url](#output\_tfe\_create\_initial\_admin\_user\_url) | URL to create TFE initial admin user. |
 | <a name="output_tfe_database_host"></a> [tfe\_database\_host](#output\_tfe\_database\_host) | Private IP address and port of TFE Cloud SQL for PostgreSQL database instance. |
@@ -339,5 +362,7 @@ Please note that there is no official Service Level Agreement (SLA) for support 
 | <a name="output_tfe_redis_use_tls"></a> [tfe\_redis\_use\_tls](#output\_tfe\_redis\_use\_tls) | Whether TFE should use TLS to connect to Redis instance. |
 | <a name="output_tfe_redis_user"></a> [tfe\_redis\_user](#output\_tfe\_redis\_user) | Username of TFE Redis instance. |
 | <a name="output_tfe_retrieve_iact_url"></a> [tfe\_retrieve\_iact\_url](#output\_tfe\_retrieve\_iact\_url) | URL to retrieve TFE initial admin creation token. |
+| <a name="output_tfe_secondary_lb_ip_address"></a> [tfe\_secondary\_lb\_ip\_address](#output\_tfe\_secondary\_lb\_ip\_address) | IP address of the optional secondary public TFE load balancer. |
+| <a name="output_tfe_secondary_url"></a> [tfe\_secondary\_url](#output\_tfe\_secondary\_url) | URL of the optional secondary TFE hostname based on `tfe_hostname_secondary`. |
 | <a name="output_tfe_url"></a> [tfe\_url](#output\_tfe\_url) | URL of TFE application based on `tfe_fqdn` input value. |
 <!-- END_TF_DOCS -->

--- a/cloud_dns.tf
+++ b/cloud_dns.tf
@@ -10,11 +10,18 @@ data "google_dns_managed_zone" "tfe" {
   name = var.cloud_dns_managed_zone_name
 }
 
+data "google_dns_managed_zone" "tfe_secondary" {
+  count = var.create_tfe_secondary_cloud_dns_record && var.secondary_cloud_dns_managed_zone_name != null ? 1 : 0
+
+  name = var.secondary_cloud_dns_managed_zone_name
+}
+
 #------------------------------------------------------------------------------
 # Cloud DNS record set
 #------------------------------------------------------------------------------
 locals {
-  tfe_dns_record_name = !endswith(var.tfe_fqdn, ".") ? "${var.tfe_fqdn}." : var.tfe_fqdn
+  tfe_dns_record_name           = !endswith(var.tfe_fqdn, ".") ? "${var.tfe_fqdn}." : var.tfe_fqdn
+  tfe_secondary_dns_record_name = var.tfe_hostname_secondary != null && !endswith(var.tfe_hostname_secondary, ".") ? "${var.tfe_hostname_secondary}." : var.tfe_hostname_secondary
 }
 
 resource "google_dns_record_set" "tfe" {
@@ -25,4 +32,14 @@ resource "google_dns_record_set" "tfe" {
   type         = "A"
   ttl          = 60
   rrdatas      = [google_compute_address.tfe_frontend_lb.address]
+}
+
+resource "google_dns_record_set" "tfe_secondary" {
+  count = var.create_tfe_secondary_cloud_dns_record && var.secondary_cloud_dns_managed_zone_name != null ? 1 : 0
+
+  managed_zone = data.google_dns_managed_zone.tfe_secondary[0].name
+  name         = local.tfe_secondary_dns_record_name
+  type         = "A"
+  ttl          = 60
+  rrdatas      = [google_compute_address.tfe_secondary_frontend_lb[0].address]
 }

--- a/compute.tf
+++ b/compute.tf
@@ -20,27 +20,36 @@ locals {
 # Metadata startup script
 #-----------------------------------------------------------------------------------
 locals {
-  tfe_startup_script_tpl = var.custom_tfe_startup_script_template != null ? "${path.cwd}/templates/${var.custom_tfe_startup_script_template}" : "${path.module}/templates/tfe_startup_script.sh.tpl"
-  redis_port             = var.redis_transit_encryption_mode == "SERVER_AUTHENTICATION" ? "6378" : "6379"
+  tfe_startup_script_tpl     = var.custom_tfe_startup_script_template != null ? "${path.cwd}/templates/${var.custom_tfe_startup_script_template}" : "${path.module}/templates/tfe_startup_script.sh.tpl"
+  redis_port                 = var.redis_transit_encryption_mode == "SERVER_AUTHENTICATION" ? "6378" : "6379"
+  secondary_hostname_enabled = var.tfe_hostname_secondary != null
+  secondary_lb_enabled       = local.secondary_hostname_enabled && var.create_secondary_tfe_lb
 
   startup_script_args = {
     # Bootstrap
-    tfe_license_secret_id             = var.tfe_license_secret_id
-    tfe_encryption_password_secret_id = var.tfe_encryption_password_secret_id
-    tfe_tls_cert_secret_id            = var.tfe_tls_cert_secret_id
-    tfe_tls_privkey_secret_id         = var.tfe_tls_privkey_secret_id
-    tfe_tls_ca_bundle_secret_id       = var.tfe_tls_ca_bundle_secret_id
-    tfe_image_repository_url          = var.tfe_image_repository_url
-    tfe_image_repository_username     = var.tfe_image_repository_username
-    tfe_image_repository_password     = var.tfe_image_repository_password != null ? var.tfe_image_repository_password : ""
-    tfe_image_name                    = var.tfe_image_name
-    tfe_image_tag                     = var.tfe_image_tag
-    container_runtime                 = var.container_runtime
-    docker_version                    = var.docker_version
+    tfe_license_secret_id                 = var.tfe_license_secret_id
+    tfe_encryption_password_secret_id     = var.tfe_encryption_password_secret_id
+    tfe_tls_cert_secret_id                = var.tfe_tls_cert_secret_id
+    tfe_tls_privkey_secret_id             = var.tfe_tls_privkey_secret_id
+    tfe_tls_ca_bundle_secret_id           = var.tfe_tls_ca_bundle_secret_id
+    tfe_tls_cert_secret_id_secondary      = var.tfe_tls_cert_secret_id_secondary != null ? var.tfe_tls_cert_secret_id_secondary : ""
+    tfe_tls_privkey_secret_id_secondary   = var.tfe_tls_privkey_secret_id_secondary != null ? var.tfe_tls_privkey_secret_id_secondary : ""
+    tfe_tls_ca_bundle_secret_id_secondary = var.tfe_tls_ca_bundle_secret_id_secondary != null ? var.tfe_tls_ca_bundle_secret_id_secondary : ""
+    tfe_image_repository_url              = var.tfe_image_repository_url
+    tfe_image_repository_username         = var.tfe_image_repository_username
+    tfe_image_repository_password         = var.tfe_image_repository_password != null ? var.tfe_image_repository_password : ""
+    tfe_image_name                        = var.tfe_image_name
+    tfe_image_tag                         = var.tfe_image_tag
+    container_runtime                     = var.container_runtime
+    docker_version                        = var.docker_version
 
     # https://developer.hashicorp.com/terraform/enterprise/flexible-deployments/install/configuration
     # TFE application settings
     tfe_hostname                  = var.tfe_fqdn
+    tfe_hostname_secondary        = var.tfe_hostname_secondary != null ? var.tfe_hostname_secondary : ""
+    tfe_oidc_hostname_choice      = var.tfe_oidc_hostname_choice
+    tfe_vcs_hostname_choice       = var.tfe_vcs_hostname_choice
+    tfe_run_task_hostname_choice  = var.tfe_run_task_hostname_choice
     tfe_operational_mode          = var.tfe_operational_mode
     tfe_capacity_concurrency      = var.tfe_capacity_concurrency
     tfe_capacity_cpu              = var.tfe_capacity_cpu
@@ -77,12 +86,15 @@ locals {
     tfe_redis_use_tls  = var.redis_transit_encryption_mode == "SERVER_AUTHENTICATION" ? true : false
 
     # TLS settings
-    tfe_tls_cert_file      = "/etc/ssl/private/terraform-enterprise/cert.pem"
-    tfe_tls_key_file       = "/etc/ssl/private/terraform-enterprise/key.pem"
-    tfe_tls_ca_bundle_file = "/etc/ssl/private/terraform-enterprise/bundle.pem"
-    tfe_tls_enforce        = var.tfe_tls_enforce
-    tfe_tls_ciphers        = "" # Leave blank to use the default ciphers
-    tfe_tls_version        = "" # Leave blank to use both TLS v1.2 and TLS v1.3
+    tfe_tls_cert_file                = "/etc/ssl/private/terraform-enterprise/cert.pem"
+    tfe_tls_key_file                 = "/etc/ssl/private/terraform-enterprise/key.pem"
+    tfe_tls_ca_bundle_file           = "/etc/ssl/private/terraform-enterprise/bundle.pem"
+    tfe_tls_cert_file_secondary      = "/etc/ssl/private/terraform-enterprise/cert-secondary.pem"
+    tfe_tls_key_file_secondary       = "/etc/ssl/private/terraform-enterprise/key-secondary.pem"
+    tfe_tls_ca_bundle_file_secondary = "/etc/ssl/private/terraform-enterprise/bundle-secondary.pem"
+    tfe_tls_enforce                  = var.tfe_tls_enforce
+    tfe_tls_ciphers                  = "" # Leave blank to use the default ciphers
+    tfe_tls_version                  = "" # Leave blank to use both TLS v1.2 and TLS v1.3
 
     # Observability settings
     tfe_log_forwarding_enabled = var.tfe_log_forwarding_enabled
@@ -292,7 +304,12 @@ resource "google_compute_firewall" "vm_allow_tfe_admin_console" {
 
 locals {
   // https://cloud.google.com/load-balancing/docs/health-check-concepts
-  health_check_probe_cidrs = var.lb_is_internal ? ["130.211.0.0/22", "35.191.0.0/16"] : ["35.191.0.0/16", "209.85.152.0/22", "209.85.204.0/22"]
+  internal_health_check_probe_cidrs = ["130.211.0.0/22", "35.191.0.0/16"]
+  external_health_check_probe_cidrs = ["35.191.0.0/16", "209.85.152.0/22", "209.85.204.0/22"]
+  health_check_probe_cidrs = distinct(concat(
+    var.lb_is_internal ? local.internal_health_check_probe_cidrs : local.external_health_check_probe_cidrs,
+    local.secondary_lb_enabled ? local.external_health_check_probe_cidrs : []
+  ))
 }
 
 resource "google_compute_firewall" "vm_allow_lb_health_checks_443" {
@@ -349,6 +366,26 @@ resource "google_compute_firewall" "vm_allow_tfe_metrics_from_cidr" {
   }
 
   source_ranges = var.cidr_allow_ingress_tfe_metrics
+  target_tags   = ["tfe-vm"]
+
+  log_config {
+    metadata = "INCLUDE_ALL_METADATA"
+  }
+}
+resource "google_compute_firewall" "vm_allow_tfe_secondary_443" {
+  count = local.secondary_lb_enabled ? 1 : 0
+
+  name        = "${var.friendly_name_prefix}-tfe-secondary-allow-443"
+  description = "Allow TCP/443 (HTTPS) ingress to TFE GCE VM instances from the optional secondary public TFE load balancer CIDR ranges."
+  network     = data.google_compute_network.vpc.self_link
+  direction   = "INGRESS"
+
+  allow {
+    protocol = "tcp"
+    ports    = [443]
+  }
+
+  source_ranges = var.cidr_allow_ingress_tfe_secondary_443
   target_tags   = ["tfe-vm"]
 
   log_config {

--- a/docs/deployment-customizations.md
+++ b/docs/deployment-customizations.md
@@ -54,6 +54,20 @@ When enabled, the module adds a second load balancer forwarding rule on `tfe_adm
 
 For internal load balancer deployments, the module automatically reserves the frontend IP with shared VIP semantics when the Admin Console is enabled so both the main HTTPS endpoint (`443`) and the Admin Console port can use the same internal IP address.
 
+### Optional secondary public callback hostname
+
+This module can optionally manage a second, public-facing passthrough Network Load Balancer for `tfe_hostname_secondary`. This is intended for cases where the primary TFE endpoint remains internal but external systems still need a public hostname for OIDC callbacks, VCS webhooks, or run tasks.
+
+- Set `tfe_hostname_secondary` plus the secondary TLS secret inputs to enable the secondary hostname inside TFE
+- Set `create_secondary_tfe_lb = true` to have the module create a dedicated public external passthrough Network Load Balancer for that hostname
+- This secondary load balancer path is only supported when the primary load balancer remains internal (`lb_is_internal = true`)
+- Restrict public ingress with `cidr_allow_ingress_tfe_secondary_443`
+
+```hcl
+tfe_hostname_secondary             = "tfe-callbacks.gcp.example.com"
+create_secondary_tfe_lb            = true
+cidr_allow_ingress_tfe_secondary_443 = ["0.0.0.0/0"]
+```
 ## DNS
 
 This module supports optionally creating a DNS record within your existing Google Cloud DNS managed zone for your TFE FQDN.
@@ -67,6 +81,13 @@ This module supports optionally creating a DNS record within your existing Googl
 ```hcl
 create_tfe_cloud_dns_record = true
 cloud_dns_managed_zone_name = "cloud-dns-managed-zone-name"
+```
+
+If you enable the optional secondary public callback hostname, you can also have the module manage a second DNS record in a public Cloud DNS zone.
+
+```hcl
+create_tfe_secondary_cloud_dns_record = true
+secondary_cloud_dns_managed_zone_name = "cloud-dns-public-zone-name"
 ```
 
 ## KMS

--- a/docs/prereqs.md
+++ b/docs/prereqs.md
@@ -53,6 +53,9 @@ resource "google_service_networking_connection" "psa" {
 | TFE TLS certificate (base64-encoded)             | `tfe_tls_cert_secret_id`            |
 | TFE TLS certificate private key (base64-encoded) | `tfe_tls_privkey_secret_id`         |
 | TFE TLS CA bundle (base64-encoded)               | `tfe_tls_ca_bundle_secret_id`       |
+| Secondary TFE TLS certificate (base64-encoded)   | `tfe_tls_cert_secret_id_secondary`  |
+| Secondary TFE TLS private key (base64-encoded)   | `tfe_tls_privkey_secret_id_secondary` |
+| Secondary TFE TLS CA bundle (base64-encoded)     | `tfe_tls_ca_bundle_secret_id_secondary` |
 
 ### Secrets Formatting
 
@@ -81,6 +84,7 @@ cat terraform.hclic
 - Start off with your certificate files in PEM format
 - These values should be base64-encoded
 - Ensure your command line interface (CLI) does not automatically inject new line characters during the base64-encoding
+- If you enable `tfe_hostname_secondary`, create a second certificate, key, and CA bundle secret for that hostname as well
 
 Example on macOS Terminal:
 

--- a/docs/tfe-cert-rotation.md
+++ b/docs/tfe-cert-rotation.md
@@ -1,6 +1,6 @@
 # TFE Certificate Rotation
 
-One of the required prerequisites to deploying this module is storing base64-encoded strings of your TFE TLS/SSL certificate and private key files in PEM format as secrets within GCP Secret Manager for bootstrapping automation purposes. The TFE metadata startup script is designed to retrieve the latest value of these secrets every time a new VM boots. Therefore, the process for updating TFE's TLS/SSL certificates is to update the values of the corresponding secrets in GCP Secrets Manager, and then to replace the running TFE GCE VM instance(s) within the Managed Instance Group (MIG) such that when the new instance(s) spawn and re-install TFE, they will retrieve and install the new certificates. See the section below for detailed steps.
+One of the required prerequisites to deploying this module is storing base64-encoded strings of your TFE TLS/SSL certificate and private key files in PEM format as secrets within GCP Secret Manager for bootstrapping automation purposes. The TFE metadata startup script is designed to retrieve the latest value of these secrets every time a new VM boots. Therefore, the process for updating TFE's TLS/SSL certificates is to update the values of the corresponding secrets in GCP Secrets Manager, and then to replace the running TFE GCE VM instance(s) within the Managed Instance Group (MIG) such that when the new instance(s) spawn and re-install TFE, they will retrieve and install the new certificates. If you use `tfe_hostname_secondary`, rotate the secondary certificate, key, and CA bundle secrets during the same maintenance window.
 
 ## Secrets
 
@@ -8,6 +8,10 @@ One of the required prerequisites to deploying this module is storing base64-enc
 |-----------------------|-----------------------------|
 | TLS/SSL certificate   | `tfe_tls_cert_secret_id`    |
 | TLS/SSL private key   | `tfe_tls_privkey_secret_id` |
+| TLS/SSL CA bundle     | `tfe_tls_ca_bundle_secret_id` |
+| Secondary TLS/SSL certificate | `tfe_tls_cert_secret_id_secondary` |
+| Secondary TLS/SSL private key | `tfe_tls_privkey_secret_id_secondary` |
+| Secondary TLS/SSL CA bundle   | `tfe_tls_ca_bundle_secret_id_secondary` |
 
 ## Procedure
 
@@ -15,7 +19,7 @@ Follow these steps to rotate the certificates for your TFE instance.
 
 1. Obtain your new TFE TLS/SSL certificate file and private key file, both in PEM format.
 
-2. Update the values of the existing secrets in GCP Secret Manager (`tfe_tls_cert_secret_id` and `tfe_tls_privkey_secret_id`, respectively). If you need assistance base64-encoding the PEM files into strings prior to updating the secret values in GCP, see the [prereqs reference](./prereqs.md#secrets-formatting).
+2. Update the values of the existing secrets in GCP Secret Manager (`tfe_tls_cert_secret_id`, `tfe_tls_privkey_secret_id`, and `tfe_tls_ca_bundle_secret_id`). If `tfe_hostname_secondary` is enabled, also update `tfe_tls_cert_secret_id_secondary`, `tfe_tls_privkey_secret_id_secondary`, and `tfe_tls_ca_bundle_secret_id_secondary`. If you need assistance base64-encoding the PEM files into strings prior to updating the secret values in GCP, see the [prereqs reference](./prereqs.md#secrets-formatting).
 
 3. During a maintenance window, connect to one of your existing TFE GCE VM instances and gracefully drain the node(s) from being able to execute any new Terraform runs.
 

--- a/docs/tfe-config-settings.md
+++ b/docs/tfe-config-settings.md
@@ -60,3 +60,20 @@ If you feel like a setting from the configuration reference is missing from the 
 Terraform Enterprise 1.2.0 introduced the readiness endpoint and 1.2.1 fixed the `200 OK` behavior required for load balancer integrations. This module therefore switches health checks to `/api/v1/health/readiness` for semver tags `1.2.1` and later, while preserving `/_health_check` for older calver releases.
 
 The module also exposes `tfe_admin_https_port` and `tfe_admin_console_disabled` so you can control the system admin endpoint separately from the main application port. If you enable the admin console, also set `cidr_allow_ingress_tfe_admin_console` to restrict access.
+
+## Secondary hostname settings
+
+TFE supports a secondary hostname for callback-driven integrations. This module exposes the core settings required for that workflow:
+
+- `tfe_hostname_secondary` -> `TFE_HOSTNAME_SECONDARY`
+- `tfe_oidc_hostname_choice` -> `TFE_OIDC_HOSTNAME_CHOICE`
+- `tfe_vcs_hostname_choice` -> `TFE_VCS_HOSTNAME_CHOICE`
+- `tfe_run_task_hostname_choice` -> `TFE_RUN_TASK_HOSTNAME_CHOICE`
+
+When `tfe_hostname_secondary` is set, the startup script also retrieves the secondary certificate, key, and CA bundle secrets and maps them to:
+
+- `TFE_TLS_CERT_FILE_SECONDARY`
+- `TFE_TLS_KEY_FILE_SECONDARY`
+- `TFE_TLS_CA_BUNDLE_FILE_SECONDARY`
+
+If `tfe_hairpin_addressing` is enabled, the module adds both the primary and secondary hostnames to the runtime extra-host mappings so run-pipeline traffic can resolve either hostname back to the local VM.

--- a/examples/docker-ubuntu-internal-nlb/README.md
+++ b/examples/docker-ubuntu-internal-nlb/README.md
@@ -11,3 +11,5 @@
 | Log forwarding destination  | `stackdriver`                |
 
 The Admin Console remains disabled by default in this example. Set `tfe_admin_console_disabled = false` and provide `cidr_allow_ingress_tfe_admin_console` if you need operator access to the admin endpoint.
+
+This example keeps the primary TFE endpoint internal by default. You can optionally add `tfe_hostname_secondary` plus `create_secondary_tfe_lb = true` to publish a dedicated public callback hostname for OIDC, VCS webhooks, and run tasks.

--- a/examples/docker-ubuntu-internal-nlb/main.tf
+++ b/examples/docker-ubuntu-internal-nlb/main.tf
@@ -36,17 +36,24 @@ module "tfe" {
   common_labels        = var.common_labels
 
   # --- Bootstrap --- #
-  tfe_license_secret_id             = var.tfe_license_secret_id
-  tfe_encryption_password_secret_id = var.tfe_encryption_password_secret_id
-  tfe_tls_cert_secret_id            = var.tfe_tls_cert_secret_id
-  tfe_tls_privkey_secret_id         = var.tfe_tls_privkey_secret_id
-  tfe_tls_ca_bundle_secret_id       = var.tfe_tls_ca_bundle_secret_id
+  tfe_license_secret_id                 = var.tfe_license_secret_id
+  tfe_encryption_password_secret_id     = var.tfe_encryption_password_secret_id
+  tfe_tls_cert_secret_id                = var.tfe_tls_cert_secret_id
+  tfe_tls_privkey_secret_id             = var.tfe_tls_privkey_secret_id
+  tfe_tls_ca_bundle_secret_id           = var.tfe_tls_ca_bundle_secret_id
+  tfe_tls_cert_secret_id_secondary      = var.tfe_tls_cert_secret_id_secondary
+  tfe_tls_privkey_secret_id_secondary   = var.tfe_tls_privkey_secret_id_secondary
+  tfe_tls_ca_bundle_secret_id_secondary = var.tfe_tls_ca_bundle_secret_id_secondary
 
   # --- TFE config settings --- #
-  tfe_fqdn                   = var.tfe_fqdn
-  tfe_image_tag              = var.tfe_image_tag
-  tfe_admin_https_port       = var.tfe_admin_https_port
-  tfe_admin_console_disabled = var.tfe_admin_console_disabled
+  tfe_fqdn                     = var.tfe_fqdn
+  tfe_hostname_secondary       = var.tfe_hostname_secondary
+  tfe_oidc_hostname_choice     = var.tfe_oidc_hostname_choice
+  tfe_vcs_hostname_choice      = var.tfe_vcs_hostname_choice
+  tfe_run_task_hostname_choice = var.tfe_run_task_hostname_choice
+  tfe_image_tag                = var.tfe_image_tag
+  tfe_admin_https_port         = var.tfe_admin_https_port
+  tfe_admin_console_disabled   = var.tfe_admin_console_disabled
 
   # --- Networking --- #
   vpc_network_name                     = var.vpc_network_name
@@ -55,11 +62,15 @@ module "tfe" {
   vm_subnet_name                       = var.vm_subnet_name
   cidr_allow_ingress_tfe_443           = var.cidr_allow_ingress_tfe_443
   cidr_allow_ingress_tfe_admin_console = var.cidr_allow_ingress_tfe_admin_console
+  create_secondary_tfe_lb              = var.create_secondary_tfe_lb
+  cidr_allow_ingress_tfe_secondary_443 = var.cidr_allow_ingress_tfe_secondary_443
   allow_ingress_vm_ssh_from_iap        = var.allow_ingress_vm_ssh_from_iap
 
   # --- DNS (optional) --- #
-  create_tfe_cloud_dns_record = var.create_tfe_cloud_dns_record
-  cloud_dns_managed_zone_name = var.cloud_dns_managed_zone_name
+  create_tfe_cloud_dns_record           = var.create_tfe_cloud_dns_record
+  cloud_dns_managed_zone_name           = var.cloud_dns_managed_zone_name
+  create_tfe_secondary_cloud_dns_record = var.create_tfe_secondary_cloud_dns_record
+  secondary_cloud_dns_managed_zone_name = var.secondary_cloud_dns_managed_zone_name
 
   # --- Compute --- #
   mig_instance_count = var.mig_instance_count

--- a/examples/docker-ubuntu-internal-nlb/terraform.tfvars.example
+++ b/examples/docker-ubuntu-internal-nlb/terraform.tfvars.example
@@ -21,18 +21,31 @@ tfe_image_tag              = "<v202409-3>"
 tfe_admin_https_port       = 9443
 tfe_admin_console_disabled = true
 
+# Optional secondary hostname for external callbacks such as OIDC, VCS, and run tasks.
+# tfe_hostname_secondary       = "<tfe-secondary.gcp.example.com>"
+# tfe_oidc_hostname_choice     = "secondary"
+# tfe_vcs_hostname_choice      = "secondary"
+# tfe_run_task_hostname_choice = "secondary"
+# tfe_tls_cert_secret_id_secondary      = "<tfe-secondary-tls-cert-base64>"
+# tfe_tls_privkey_secret_id_secondary   = "<tfe-secondary-tls-privkey-base64>"
+# tfe_tls_ca_bundle_secret_id_secondary = "<tfe-secondary-tls-ca-bundle-base64>"
+
 # --- Networking --- #
 vpc_network_name                     = "<tfe-vpc-network-name>"
 lb_is_internal                       = true
 lb_subnet_name                       = "<tfe-lb-subnet-name>" # can be the same as VM subnet if desired
 vm_subnet_name                       = "<tfe-vm-subnet-name>"
 cidr_allow_ingress_tfe_443           = ["<0.0.0.0/0>"] # CIDR ranges of TFE users/clients, VCS, and other tooling that will access TFE
+# create_secondary_tfe_lb            = true
+# cidr_allow_ingress_tfe_secondary_443 = ["<0.0.0.0/0>"]
 cidr_allow_ingress_tfe_admin_console = ["<10.0.0.0/16>"] # required when tfe_admin_console_disabled = false
 allow_ingress_vm_ssh_from_iap        = true
 
 # --- DNS (optional) --- #
 create_tfe_cloud_dns_record = <true>
 cloud_dns_managed_zone_name = "<google-cloud-dns-zone-name>"
+# create_tfe_secondary_cloud_dns_record = <true>
+# secondary_cloud_dns_managed_zone_name = "<google-cloud-dns-public-zone-name>"
 
 # --- Compute --- #
 mig_instance_count = 1

--- a/examples/docker-ubuntu-internal-nlb/variables.tf
+++ b/examples/docker-ubuntu-internal-nlb/variables.tf
@@ -59,6 +59,24 @@ variable "tfe_tls_ca_bundle_secret_id" {
   description = "Name of Google Secret Manager secret for private/custom TLS Certificate Authority (CA) bundle in PEM format. Secret must be stored as a base64-encoded string."
 }
 
+variable "tfe_tls_cert_secret_id_secondary" {
+  type        = string
+  description = "Name of Google Secret Manager secret for the optional secondary TFE TLS certificate in PEM format."
+  default     = null
+}
+
+variable "tfe_tls_privkey_secret_id_secondary" {
+  type        = string
+  description = "Name of Google Secret Manager secret for the optional secondary TFE TLS private key in PEM format."
+  default     = null
+}
+
+variable "tfe_tls_ca_bundle_secret_id_secondary" {
+  type        = string
+  description = "Name of Google Secret Manager secret for the optional secondary TFE TLS CA bundle in PEM format."
+  default     = null
+}
+
 variable "tfe_encryption_password_secret_id" {
   type        = string
   description = "Name of Google Secret Manager secret for TFE encryption password."
@@ -105,6 +123,30 @@ variable "tfe_image_repository_password" {
 variable "tfe_fqdn" {
   type        = string
   description = "Fully qualified domain name (FQDN) of TFE instance. This name should resolve to the TFE load balancer IP address and will be what users/clients use to access TFE."
+}
+
+variable "tfe_hostname_secondary" {
+  type        = string
+  description = "Optional secondary hostname for TFE."
+  default     = null
+}
+
+variable "tfe_oidc_hostname_choice" {
+  type        = string
+  description = "Hostname choice for OIDC callback URLs."
+  default     = "primary"
+}
+
+variable "tfe_vcs_hostname_choice" {
+  type        = string
+  description = "Hostname choice for VCS webhook callback URLs."
+  default     = "primary"
+}
+
+variable "tfe_run_task_hostname_choice" {
+  type        = string
+  description = "Hostname choice for run task callbacks."
+  default     = "primary"
 }
 
 variable "tfe_operational_mode" {
@@ -324,6 +366,18 @@ variable "cidr_allow_ingress_tfe_admin_console" {
   }
 }
 
+variable "create_secondary_tfe_lb" {
+  type        = bool
+  description = "Boolean to create a dedicated public secondary load balancer for `tfe_hostname_secondary`."
+  default     = false
+}
+
+variable "cidr_allow_ingress_tfe_secondary_443" {
+  type        = list(string)
+  description = "List of CIDR ranges to allow TCP/443 (HTTPS) inbound to the optional secondary public TFE load balancer."
+  default     = ["0.0.0.0/0"]
+}
+
 variable "cidr_allow_ingress_vm_ssh" {
   type        = list(string)
   description = "List of CIDR ranges to allow TCP/22 (SSH) inbound to TFE GCE instances."
@@ -360,6 +414,18 @@ variable "cloud_dns_managed_zone_name" {
     condition     = var.create_tfe_cloud_dns_record ? var.cloud_dns_managed_zone_name != null : true
     error_message = "Value must be set when `create_tfe_cloud_dns_record` is `true`."
   }
+}
+
+variable "create_tfe_secondary_cloud_dns_record" {
+  type        = bool
+  description = "Boolean to create a Google Cloud DNS record for `tfe_hostname_secondary` when the module also creates the optional secondary load balancer."
+  default     = false
+}
+
+variable "secondary_cloud_dns_managed_zone_name" {
+  type        = string
+  description = "Name of Google Cloud DNS managed zone to create the secondary TFE DNS record in."
+  default     = null
 }
 
 #------------------------------------------------------------------------------

--- a/examples/podman-rhel-internal-nlb/README.md
+++ b/examples/podman-rhel-internal-nlb/README.md
@@ -11,3 +11,5 @@
 | Log forwarding destination  | `stackdriver`                |
 
 The Admin Console remains disabled by default in this example. Set `tfe_admin_console_disabled = false` and provide `cidr_allow_ingress_tfe_admin_console` if you need operator access to the admin endpoint.
+
+This example keeps the primary TFE endpoint internal by default. You can optionally add `tfe_hostname_secondary` plus `create_secondary_tfe_lb = true` to publish a dedicated public callback hostname for OIDC, VCS webhooks, and run tasks.

--- a/examples/podman-rhel-internal-nlb/main.tf
+++ b/examples/podman-rhel-internal-nlb/main.tf
@@ -36,17 +36,24 @@ module "tfe" {
   common_labels        = var.common_labels
 
   # --- Bootstrap --- #
-  tfe_license_secret_id             = var.tfe_license_secret_id
-  tfe_encryption_password_secret_id = var.tfe_encryption_password_secret_id
-  tfe_tls_cert_secret_id            = var.tfe_tls_cert_secret_id
-  tfe_tls_privkey_secret_id         = var.tfe_tls_privkey_secret_id
-  tfe_tls_ca_bundle_secret_id       = var.tfe_tls_ca_bundle_secret_id
+  tfe_license_secret_id                 = var.tfe_license_secret_id
+  tfe_encryption_password_secret_id     = var.tfe_encryption_password_secret_id
+  tfe_tls_cert_secret_id                = var.tfe_tls_cert_secret_id
+  tfe_tls_privkey_secret_id             = var.tfe_tls_privkey_secret_id
+  tfe_tls_ca_bundle_secret_id           = var.tfe_tls_ca_bundle_secret_id
+  tfe_tls_cert_secret_id_secondary      = var.tfe_tls_cert_secret_id_secondary
+  tfe_tls_privkey_secret_id_secondary   = var.tfe_tls_privkey_secret_id_secondary
+  tfe_tls_ca_bundle_secret_id_secondary = var.tfe_tls_ca_bundle_secret_id_secondary
 
   # --- TFE config settings --- #
-  tfe_fqdn                   = var.tfe_fqdn
-  tfe_image_tag              = var.tfe_image_tag
-  tfe_admin_https_port       = var.tfe_admin_https_port
-  tfe_admin_console_disabled = var.tfe_admin_console_disabled
+  tfe_fqdn                     = var.tfe_fqdn
+  tfe_hostname_secondary       = var.tfe_hostname_secondary
+  tfe_oidc_hostname_choice     = var.tfe_oidc_hostname_choice
+  tfe_vcs_hostname_choice      = var.tfe_vcs_hostname_choice
+  tfe_run_task_hostname_choice = var.tfe_run_task_hostname_choice
+  tfe_image_tag                = var.tfe_image_tag
+  tfe_admin_https_port         = var.tfe_admin_https_port
+  tfe_admin_console_disabled   = var.tfe_admin_console_disabled
 
   # --- Networking --- #
   vpc_network_name                     = var.vpc_network_name
@@ -55,11 +62,15 @@ module "tfe" {
   vm_subnet_name                       = var.vm_subnet_name
   cidr_allow_ingress_tfe_443           = var.cidr_allow_ingress_tfe_443
   cidr_allow_ingress_tfe_admin_console = var.cidr_allow_ingress_tfe_admin_console
+  create_secondary_tfe_lb              = var.create_secondary_tfe_lb
+  cidr_allow_ingress_tfe_secondary_443 = var.cidr_allow_ingress_tfe_secondary_443
   allow_ingress_vm_ssh_from_iap        = var.allow_ingress_vm_ssh_from_iap
 
   # --- DNS (optional) --- #
-  create_tfe_cloud_dns_record = var.create_tfe_cloud_dns_record
-  cloud_dns_managed_zone_name = var.cloud_dns_managed_zone_name
+  create_tfe_cloud_dns_record           = var.create_tfe_cloud_dns_record
+  cloud_dns_managed_zone_name           = var.cloud_dns_managed_zone_name
+  create_tfe_secondary_cloud_dns_record = var.create_tfe_secondary_cloud_dns_record
+  secondary_cloud_dns_managed_zone_name = var.secondary_cloud_dns_managed_zone_name
 
   # --- Compute --- #
   mig_instance_count = var.mig_instance_count

--- a/examples/podman-rhel-internal-nlb/terraform.tfvars.example
+++ b/examples/podman-rhel-internal-nlb/terraform.tfvars.example
@@ -21,18 +21,31 @@ tfe_image_tag              = "<v202409-3>"
 tfe_admin_https_port       = 9443
 tfe_admin_console_disabled = true
 
+# Optional secondary hostname for external callbacks such as OIDC, VCS, and run tasks.
+# tfe_hostname_secondary       = "<tfe-secondary.gcp.example.com>"
+# tfe_oidc_hostname_choice     = "secondary"
+# tfe_vcs_hostname_choice      = "secondary"
+# tfe_run_task_hostname_choice = "secondary"
+# tfe_tls_cert_secret_id_secondary      = "<tfe-secondary-tls-cert-base64>"
+# tfe_tls_privkey_secret_id_secondary   = "<tfe-secondary-tls-privkey-base64>"
+# tfe_tls_ca_bundle_secret_id_secondary = "<tfe-secondary-tls-ca-bundle-base64>"
+
 # --- Networking --- #
 vpc_network_name                     = "<tfe-vpc-network-name>"
 lb_is_internal                       = true
 lb_subnet_name                       = "<tfe-lb-subnet-name>" # can be the same as VM subnet if desired
 vm_subnet_name                       = "<tfe-vm-subnet-name>"
 cidr_allow_ingress_tfe_443           = ["<0.0.0.0/0>"] # CIDR ranges of TFE users/clients, VCS, and other tooling that will access TFE
+# create_secondary_tfe_lb            = true
+# cidr_allow_ingress_tfe_secondary_443 = ["<0.0.0.0/0>"]
 cidr_allow_ingress_tfe_admin_console = ["<10.0.0.0/16>"] # required when tfe_admin_console_disabled = false
 allow_ingress_vm_ssh_from_iap        = true
 
 # --- DNS (optional) --- #
 create_tfe_cloud_dns_record = <true>
 cloud_dns_managed_zone_name = "<google-cloud-dns-zone-name>"
+# create_tfe_secondary_cloud_dns_record = <true>
+# secondary_cloud_dns_managed_zone_name = "<google-cloud-dns-public-zone-name>"
 
 # --- Compute --- #
 mig_instance_count = 1

--- a/examples/podman-rhel-internal-nlb/variables.tf
+++ b/examples/podman-rhel-internal-nlb/variables.tf
@@ -59,6 +59,24 @@ variable "tfe_tls_ca_bundle_secret_id" {
   description = "Name of Google Secret Manager secret for private/custom TLS Certificate Authority (CA) bundle in PEM format. Secret must be stored as a base64-encoded string."
 }
 
+variable "tfe_tls_cert_secret_id_secondary" {
+  type        = string
+  description = "Name of Google Secret Manager secret for the optional secondary TFE TLS certificate in PEM format."
+  default     = null
+}
+
+variable "tfe_tls_privkey_secret_id_secondary" {
+  type        = string
+  description = "Name of Google Secret Manager secret for the optional secondary TFE TLS private key in PEM format."
+  default     = null
+}
+
+variable "tfe_tls_ca_bundle_secret_id_secondary" {
+  type        = string
+  description = "Name of Google Secret Manager secret for the optional secondary TFE TLS CA bundle in PEM format."
+  default     = null
+}
+
 variable "tfe_encryption_password_secret_id" {
   type        = string
   description = "Name of Google Secret Manager secret for TFE encryption password."
@@ -105,6 +123,30 @@ variable "tfe_image_repository_password" {
 variable "tfe_fqdn" {
   type        = string
   description = "Fully qualified domain name (FQDN) of TFE instance. This name should resolve to the TFE load balancer IP address and will be what users/clients use to access TFE."
+}
+
+variable "tfe_hostname_secondary" {
+  type        = string
+  description = "Optional secondary hostname for TFE."
+  default     = null
+}
+
+variable "tfe_oidc_hostname_choice" {
+  type        = string
+  description = "Hostname choice for OIDC callback URLs."
+  default     = "primary"
+}
+
+variable "tfe_vcs_hostname_choice" {
+  type        = string
+  description = "Hostname choice for VCS webhook callback URLs."
+  default     = "primary"
+}
+
+variable "tfe_run_task_hostname_choice" {
+  type        = string
+  description = "Hostname choice for run task callbacks."
+  default     = "primary"
 }
 
 variable "tfe_operational_mode" {
@@ -324,6 +366,18 @@ variable "cidr_allow_ingress_tfe_admin_console" {
   }
 }
 
+variable "create_secondary_tfe_lb" {
+  type        = bool
+  description = "Boolean to create a dedicated public secondary load balancer for `tfe_hostname_secondary`."
+  default     = false
+}
+
+variable "cidr_allow_ingress_tfe_secondary_443" {
+  type        = list(string)
+  description = "List of CIDR ranges to allow TCP/443 (HTTPS) inbound to the optional secondary public TFE load balancer."
+  default     = ["0.0.0.0/0"]
+}
+
 variable "cidr_allow_ingress_vm_ssh" {
   type        = list(string)
   description = "List of CIDR ranges to allow TCP/22 (SSH) inbound to TFE GCE instances."
@@ -360,6 +414,18 @@ variable "cloud_dns_managed_zone_name" {
     condition     = var.create_tfe_cloud_dns_record ? var.cloud_dns_managed_zone_name != null : true
     error_message = "Value must be set when `create_tfe_cloud_dns_record` is `true`."
   }
+}
+
+variable "create_tfe_secondary_cloud_dns_record" {
+  type        = bool
+  description = "Boolean to create a Google Cloud DNS record for `tfe_hostname_secondary` when the module also creates the optional secondary load balancer."
+  default     = false
+}
+
+variable "secondary_cloud_dns_managed_zone_name" {
+  type        = string
+  description = "Name of Google Cloud DNS managed zone to create the secondary TFE DNS record in."
+  default     = null
 }
 
 #------------------------------------------------------------------------------

--- a/iam.tf
+++ b/iam.tf
@@ -66,6 +66,30 @@ resource "google_secret_manager_secret_iam_member" "tfe_ca_bundle" {
   member    = "serviceAccount:${google_service_account.tfe.email}"
 }
 
+resource "google_secret_manager_secret_iam_member" "tfe_secondary_cert" {
+  count = var.tfe_tls_cert_secret_id_secondary != null ? 1 : 0
+
+  secret_id = var.tfe_tls_cert_secret_id_secondary
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.tfe.email}"
+}
+
+resource "google_secret_manager_secret_iam_member" "tfe_secondary_privkey" {
+  count = var.tfe_tls_privkey_secret_id_secondary != null ? 1 : 0
+
+  secret_id = var.tfe_tls_privkey_secret_id_secondary
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.tfe.email}"
+}
+
+resource "google_secret_manager_secret_iam_member" "tfe_secondary_ca_bundle" {
+  count = var.tfe_tls_ca_bundle_secret_id_secondary != null ? 1 : 0
+
+  secret_id = var.tfe_tls_ca_bundle_secret_id_secondary
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.tfe.email}"
+}
+
 resource "google_project_iam_member" "tfe_logging_stackdriver" {
   count = var.tfe_log_forwarding_enabled && var.log_fwd_destination_type == "stackdriver" ? 1 : 0
 

--- a/load_balancing.tf
+++ b/load_balancing.tf
@@ -107,3 +107,59 @@ resource "google_compute_region_health_check" "tfe_backend_lb" {
     request_path = local.tfe_health_check_path
   }
 }
+
+#-----------------------------------------------------------------------------------
+# Secondary frontend (optional)
+#-----------------------------------------------------------------------------------
+resource "google_compute_address" "tfe_secondary_frontend_lb" {
+  count = local.secondary_lb_enabled ? 1 : 0
+
+  name         = "${var.friendly_name_prefix}-tfe-secondary-frontend-lb-ip"
+  description  = "Static IP to associate with the optional secondary public TFE load balancer forwarding rule."
+  address_type = "EXTERNAL"
+  network_tier = "PREMIUM"
+}
+
+resource "google_compute_forwarding_rule" "tfe_secondary_frontend_lb" {
+  count = local.secondary_lb_enabled ? 1 : 0
+
+  name                  = "${var.friendly_name_prefix}-tfe-secondary-frontend-lb-external"
+  backend_service       = google_compute_region_backend_service.tfe_secondary_backend_lb[0].id
+  ip_protocol           = "TCP"
+  load_balancing_scheme = "EXTERNAL"
+  ports                 = [443]
+  ip_address            = google_compute_address.tfe_secondary_frontend_lb[0].address
+}
+
+#-----------------------------------------------------------------------------------
+# Secondary backend (optional)
+#-----------------------------------------------------------------------------------
+resource "google_compute_region_backend_service" "tfe_secondary_backend_lb" {
+  count = local.secondary_lb_enabled ? 1 : 0
+
+  name                  = "${var.friendly_name_prefix}-tfe-secondary-backend-lb-external"
+  protocol              = "TCP"
+  load_balancing_scheme = "EXTERNAL"
+
+  backend {
+    description    = "TFE secondary external regional backend service."
+    group          = google_compute_region_instance_group_manager.tfe.instance_group
+    balancing_mode = "CONNECTION"
+    failover       = false
+  }
+
+  health_checks = [google_compute_region_health_check.tfe_secondary_backend_lb[0].self_link]
+}
+
+resource "google_compute_region_health_check" "tfe_secondary_backend_lb" {
+  count = local.secondary_lb_enabled ? 1 : 0
+
+  name               = "${var.friendly_name_prefix}-tfe-secondary-backend-svc-health-check"
+  check_interval_sec = 5
+  timeout_sec        = 5
+
+  https_health_check {
+    port         = 443
+    request_path = local.tfe_health_check_path
+  }
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -24,6 +24,11 @@ output "tfe_admin_console_url_pattern" {
   description = "URL pattern to access the TFE Admin Console. Only applicable when `tfe_admin_console_disabled` is `false`."
 }
 
+output "tfe_secondary_url" {
+  value       = var.tfe_hostname_secondary != null ? "https://${var.tfe_hostname_secondary}" : null
+  description = "URL of the optional secondary TFE hostname based on `tfe_hostname_secondary`."
+}
+
 #------------------------------------------------------------------------------
 # Load balancer
 #------------------------------------------------------------------------------
@@ -35,6 +40,11 @@ output "tfe_lb_ip_address" {
 output "tfe_load_balancing_scheme" {
   value       = google_compute_forwarding_rule.tfe_frontend_lb.load_balancing_scheme
   description = "Load balancing scheme of TFE front end load balancer (forwarding rule)."
+}
+
+output "tfe_secondary_lb_ip_address" {
+  value       = local.secondary_lb_enabled ? google_compute_address.tfe_secondary_frontend_lb[0].address : null
+  description = "IP address of the optional secondary public TFE load balancer."
 }
 
 #------------------------------------------------------------------------------

--- a/templates/tfe_startup_script.sh.tpl
+++ b/templates/tfe_startup_script.sh.tpl
@@ -179,6 +179,12 @@ services:
     environment:
       # Application settings
       TFE_HOSTNAME: ${tfe_hostname}
+%{ if tfe_hostname_secondary != "" ~}
+      TFE_HOSTNAME_SECONDARY: ${tfe_hostname_secondary}
+      TFE_OIDC_HOSTNAME_CHOICE: ${tfe_oidc_hostname_choice}
+      TFE_VCS_HOSTNAME_CHOICE: ${tfe_vcs_hostname_choice}
+      TFE_RUN_TASK_HOSTNAME_CHOICE: ${tfe_run_task_hostname_choice}
+%{ endif ~}
       TFE_LICENSE: $TFE_LICENSE
       TFE_LICENSE_PATH: ""
       TFE_OPERATIONAL_MODE: ${tfe_operational_mode}
@@ -224,6 +230,11 @@ services:
       TFE_TLS_CERT_FILE: ${tfe_tls_cert_file}
       TFE_TLS_KEY_FILE: ${tfe_tls_key_file}
       TFE_TLS_CA_BUNDLE_FILE: ${tfe_tls_ca_bundle_file}
+%{ if tfe_hostname_secondary != "" ~}
+      TFE_TLS_CERT_FILE_SECONDARY: ${tfe_tls_cert_file_secondary}
+      TFE_TLS_KEY_FILE_SECONDARY: ${tfe_tls_key_file_secondary}
+      TFE_TLS_CA_BUNDLE_FILE_SECONDARY: ${tfe_tls_ca_bundle_file_secondary}
+%{ endif ~}
       TFE_TLS_CIPHERS: ${tfe_tls_ciphers}
       TFE_TLS_ENFORCE: ${tfe_tls_enforce}
       TFE_TLS_VERSION: ${tfe_tls_version}
@@ -241,7 +252,11 @@ services:
       TFE_RUN_PIPELINE_DOCKER_NETWORK: ${tfe_run_pipeline_docker_network}
 %{ if tfe_hairpin_addressing ~}
       # Prevent loopback with layer 4 load balancer with hairpinning TFE agent traffic
+%{ if tfe_hostname_secondary != "" ~}
+      TFE_RUN_PIPELINE_DOCKER_EXTRA_HOSTS: ${tfe_hostname}:$VM_PRIVATE_IP,${tfe_hostname_secondary}:$VM_PRIVATE_IP
+%{ else ~}
       TFE_RUN_PIPELINE_DOCKER_EXTRA_HOSTS: ${tfe_hostname}:$VM_PRIVATE_IP
+%{ endif ~}
 %{ endif ~}
 
       # Network settings
@@ -259,6 +274,9 @@ services:
 %{ if tfe_hairpin_addressing ~}
     extra_hosts:
       - ${tfe_hostname}:$VM_PRIVATE_IP
+%{ if tfe_hostname_secondary != "" ~}
+      - ${tfe_hostname_secondary}:$VM_PRIVATE_IP
+%{ endif ~}
 %{ endif ~}
     cap_add:
       - IPC_LOCK
@@ -317,12 +335,25 @@ spec:
     - ip: $VM_PRIVATE_IP
       hostnames:
         - "${tfe_hostname}"
+%{ if tfe_hostname_secondary != "" ~}
+        - "${tfe_hostname_secondary}"
+%{ endif ~}
 %{ endif ~}
   containers:
   - env:
     # Application settings
     - name: "TFE_HOSTNAME"
       value: ${tfe_hostname}
+%{ if tfe_hostname_secondary != "" ~}
+    - name: "TFE_HOSTNAME_SECONDARY"
+      value: ${tfe_hostname_secondary}
+    - name: "TFE_OIDC_HOSTNAME_CHOICE"
+      value: ${tfe_oidc_hostname_choice}
+    - name: "TFE_VCS_HOSTNAME_CHOICE"
+      value: ${tfe_vcs_hostname_choice}
+    - name: "TFE_RUN_TASK_HOSTNAME_CHOICE"
+      value: ${tfe_run_task_hostname_choice}
+%{ endif ~}
     - name: "TFE_LICENSE"
       value: $TFE_LICENSE
     - name: "TFE_LICENSE_PATH"
@@ -401,6 +432,14 @@ spec:
       value: ${tfe_tls_key_file}
     - name: "TFE_TLS_CA_BUNDLE_FILE"
       value: ${tfe_tls_ca_bundle_file}
+%{ if tfe_hostname_secondary != "" ~}
+    - name: "TFE_TLS_CERT_FILE_SECONDARY"
+      value: ${tfe_tls_cert_file_secondary}
+    - name: "TFE_TLS_KEY_FILE_SECONDARY"
+      value: ${tfe_tls_key_file_secondary}
+    - name: "TFE_TLS_CA_BUNDLE_FILE_SECONDARY"
+      value: ${tfe_tls_ca_bundle_file_secondary}
+%{ endif ~}
     - name: "TFE_TLS_CIPHERS"
       value: ${tfe_tls_ciphers}
     - name: "TFE_TLS_ENFORCE"
@@ -429,8 +468,13 @@ spec:
       value: ${tfe_run_pipeline_docker_network}
 %{ if tfe_hairpin_addressing ~}
       # Prevent loopback with layer 4 load balancer with hairpinning TFE agent traffic
+%{ if tfe_hostname_secondary != "" ~}
+    - name: "TFE_RUN_PIPELINE_DOCKER_EXTRA_HOSTS"
+      value: ${tfe_hostname}:$VM_PRIVATE_IP,${tfe_hostname_secondary}:$VM_PRIVATE_IP
+%{ else ~}
     - name: "TFE_RUN_PIPELINE_DOCKER_EXTRA_HOSTS"
       value: ${tfe_hostname}:$VM_PRIVATE_IP
+%{ endif ~}
 %{ endif ~}
 
     # Network settings
@@ -601,6 +645,17 @@ function main {
   retrieve_cert_from_gcp_sm "${tfe_tls_privkey_secret_id}" "$TFE_TLS_CERTS_DIR/key.pem"
   log "INFO" "Retrieving TFE_TLS_CA_BUNDLE_FILE..."
   retrieve_cert_from_gcp_sm "${tfe_tls_ca_bundle_secret_id}" "$TFE_TLS_CERTS_DIR/bundle.pem"
+%{ if tfe_hostname_secondary != "" ~}
+  log "INFO" "Retrieving TFE_TLS_CERT_FILE_SECONDARY..."
+  retrieve_cert_from_gcp_sm "${tfe_tls_cert_secret_id_secondary}" "$TFE_TLS_CERTS_DIR/cert-secondary.pem"
+  log "INFO" "Retrieving TFE_TLS_KEY_FILE_SECONDARY..."
+  retrieve_cert_from_gcp_sm "${tfe_tls_privkey_secret_id_secondary}" "$TFE_TLS_CERTS_DIR/key-secondary.pem"
+  log "INFO" "Retrieving TFE_TLS_CA_BUNDLE_FILE_SECONDARY..."
+  retrieve_cert_from_gcp_sm "${tfe_tls_ca_bundle_secret_id_secondary}" "$TFE_TLS_CERTS_DIR/bundle-secondary.pem"
+  log "INFO" "Appending secondary TLS CA bundle to primary CA bundle."
+  printf '\n' >> "$TFE_TLS_CERTS_DIR/bundle.pem"
+  cat "$TFE_TLS_CERTS_DIR/bundle-secondary.pem" >> "$TFE_TLS_CERTS_DIR/bundle.pem"
+%{ endif ~}
 
   if [[ "${tfe_log_forwarding_enabled}" == "true" ]]; then
     log "INFO" "Generating '$TFE_LOG_FORWARDING_CONFIG_PATH' file for log forwarding."

--- a/variables.tf
+++ b/variables.tf
@@ -59,6 +59,39 @@ variable "tfe_tls_ca_bundle_secret_id" {
   description = "Name of Google Secret Manager secret for private/custom TLS Certificate Authority (CA) bundle in PEM format. Secret must be stored as a base64-encoded string."
 }
 
+variable "tfe_tls_cert_secret_id_secondary" {
+  type        = string
+  description = "Name of Google Secret Manager secret for the secondary TFE TLS certificate in PEM format. Secret must be stored as a base64-encoded string. Required when `tfe_hostname_secondary` is set."
+  default     = null
+
+  validation {
+    condition     = var.tfe_hostname_secondary != null ? var.tfe_tls_cert_secret_id_secondary != null : true
+    error_message = "Value must be set when `tfe_hostname_secondary` is set."
+  }
+}
+
+variable "tfe_tls_privkey_secret_id_secondary" {
+  type        = string
+  description = "Name of Google Secret Manager secret for the secondary TFE TLS private key in PEM format. Secret must be stored as a base64-encoded string. Required when `tfe_hostname_secondary` is set."
+  default     = null
+
+  validation {
+    condition     = var.tfe_hostname_secondary != null ? var.tfe_tls_privkey_secret_id_secondary != null : true
+    error_message = "Value must be set when `tfe_hostname_secondary` is set."
+  }
+}
+
+variable "tfe_tls_ca_bundle_secret_id_secondary" {
+  type        = string
+  description = "Name of Google Secret Manager secret for the secondary TFE TLS CA bundle in PEM format. Secret must be stored as a base64-encoded string. Required when `tfe_hostname_secondary` is set."
+  default     = null
+
+  validation {
+    condition     = var.tfe_hostname_secondary != null ? var.tfe_tls_ca_bundle_secret_id_secondary != null : true
+    error_message = "Value must be set when `tfe_hostname_secondary` is set."
+  }
+}
+
 variable "tfe_encryption_password_secret_id" {
   type        = string
   description = "Name of Google Secret Manager secret for TFE encryption password."
@@ -105,6 +138,60 @@ variable "tfe_image_repository_password" {
 variable "tfe_fqdn" {
   type        = string
   description = "Fully qualified domain name (FQDN) of TFE instance. This name should resolve to the TFE load balancer IP address and will be what users/clients use to access TFE."
+}
+
+variable "tfe_hostname_secondary" {
+  type        = string
+  description = "Optional secondary hostname for TFE. Use this when you need a second externally reachable hostname for OIDC callbacks, VCS webhooks, or run tasks."
+  default     = null
+}
+
+variable "tfe_oidc_hostname_choice" {
+  type        = string
+  description = "Hostname choice for OIDC callback URLs. Valid values are `primary` or `secondary`."
+  default     = "primary"
+
+  validation {
+    condition     = contains(["primary", "secondary"], var.tfe_oidc_hostname_choice)
+    error_message = "Value must be `primary` or `secondary`."
+  }
+
+  validation {
+    condition     = var.tfe_oidc_hostname_choice != "secondary" || var.tfe_hostname_secondary != null
+    error_message = "Value can only be `secondary` when `tfe_hostname_secondary` is set."
+  }
+}
+
+variable "tfe_vcs_hostname_choice" {
+  type        = string
+  description = "Hostname choice for VCS webhook callback URLs. Valid values are `primary` or `secondary`."
+  default     = "primary"
+
+  validation {
+    condition     = contains(["primary", "secondary"], var.tfe_vcs_hostname_choice)
+    error_message = "Value must be `primary` or `secondary`."
+  }
+
+  validation {
+    condition     = var.tfe_vcs_hostname_choice != "secondary" || var.tfe_hostname_secondary != null
+    error_message = "Value can only be `secondary` when `tfe_hostname_secondary` is set."
+  }
+}
+
+variable "tfe_run_task_hostname_choice" {
+  type        = string
+  description = "Hostname choice for run task callbacks. Valid values are `primary` or `secondary`."
+  default     = "primary"
+
+  validation {
+    condition     = contains(["primary", "secondary"], var.tfe_run_task_hostname_choice)
+    error_message = "Value must be `primary` or `secondary`."
+  }
+
+  validation {
+    condition     = var.tfe_run_task_hostname_choice != "secondary" || var.tfe_hostname_secondary != null
+    error_message = "Value can only be `secondary` when `tfe_hostname_secondary` is set."
+  }
 }
 
 variable "tfe_operational_mode" {
@@ -324,6 +411,27 @@ variable "cidr_allow_ingress_tfe_admin_console" {
   }
 }
 
+variable "create_secondary_tfe_lb" {
+  type        = bool
+  description = "Boolean to create a dedicated public external passthrough Network Load Balancer for `tfe_hostname_secondary`. This is only supported when the primary load balancer remains internal (`lb_is_internal = true`)."
+  default     = false
+
+  validation {
+    condition     = !var.create_secondary_tfe_lb || var.tfe_hostname_secondary != null
+    error_message = "Value can only be `true` when `tfe_hostname_secondary` is set."
+  }
+
+  validation {
+    condition     = !var.create_secondary_tfe_lb || var.lb_is_internal
+    error_message = "Value can only be `true` when `lb_is_internal` is `true`."
+  }
+}
+
+variable "cidr_allow_ingress_tfe_secondary_443" {
+  type        = list(string)
+  description = "List of CIDR ranges to allow TCP/443 (HTTPS) inbound to the optional secondary public TFE load balancer."
+  default     = ["0.0.0.0/0"]
+}
 variable "cidr_allow_ingress_vm_ssh" {
   type        = list(string)
   description = "List of CIDR ranges to allow TCP/22 (SSH) inbound to TFE GCE instances."
@@ -359,6 +467,28 @@ variable "cloud_dns_managed_zone_name" {
   validation {
     condition     = var.create_tfe_cloud_dns_record ? var.cloud_dns_managed_zone_name != null : true
     error_message = "Value must be set when `create_tfe_cloud_dns_record` is `true`."
+  }
+}
+
+variable "create_tfe_secondary_cloud_dns_record" {
+  type        = bool
+  description = "Boolean to create a Google Cloud DNS record for `tfe_hostname_secondary`, resolving to the optional secondary public load balancer. `secondary_cloud_dns_managed_zone_name` is required when `true`."
+  default     = false
+
+  validation {
+    condition     = !var.create_tfe_secondary_cloud_dns_record || var.create_secondary_tfe_lb
+    error_message = "Value can only be `true` when `create_secondary_tfe_lb` is `true`."
+  }
+}
+
+variable "secondary_cloud_dns_managed_zone_name" {
+  type        = string
+  description = "Name of Google Cloud DNS managed zone to create the secondary TFE DNS record in. Required when `create_tfe_secondary_cloud_dns_record` is `true`."
+  default     = null
+
+  validation {
+    condition     = var.create_tfe_secondary_cloud_dns_record ? var.secondary_cloud_dns_managed_zone_name != null : true
+    error_message = "Value must be set when `create_tfe_secondary_cloud_dns_record` is `true`."
   }
 }
 


### PR DESCRIPTION
## Summary
- port the intent of terraform-aws-terraform-enterprise-hvd PR #48 into the Google module
- add TFE secondary hostname settings and hostname-choice controls for OIDC, VCS webhooks, and run tasks
- retrieve secondary TLS certificate, key, and CA bundle secrets from Google Secret Manager and wire them into the TFE runtime
- optionally create a dedicated public external passthrough Network Load Balancer and Cloud DNS record for the secondary hostname when the primary load balancer remains internal
- update outputs, examples, README, and supporting docs for the new secondary-hostname workflow

## Google-specific adaptation
- `tfe_hostname_secondary` can be used with or without a module-managed secondary endpoint
- `create_secondary_tfe_lb` is intentionally limited to deployments that keep the primary load balancer internal so the secondary hostname can serve as a distinct public callback path
- the startup script adds both hostnames to hairpin extra-host mappings when enabled and appends the secondary CA bundle to the primary bundle during bootstrap
- load balancer health-check firewall ranges now account for mixed internal-primary and public-secondary topologies

## Testing
- `task terraform-docs`
- `task test`

## Notes
This draft follows the same high-level UX as the AWS change set while adapting the load balancing, DNS, firewall, and secret-management pieces to GCP primitives.