### PR TITLE
fix: use shared VIP for internal admin console forwarding rule

### DIFF
--- a/docs/deployment-customizations.md
+++ b/docs/deployment-customizations.md
@@ -52,6 +52,8 @@ cidr_allow_ingress_tfe_admin_console = ["10.0.0.0/16"]
 
 When enabled, the module adds a second load balancer forwarding rule on `tfe_admin_https_port`, opens the matching VM firewall rule, and exposes the Admin Console URL via the `tfe_admin_console_url_pattern` output.
 
+For internal load balancer deployments, the module automatically reserves the frontend IP with shared VIP semantics when the Admin Console is enabled so both the main HTTPS endpoint (`443`) and the Admin Console port can use the same internal IP address.
+
 ## DNS
 
 This module supports optionally creating a DNS record within your existing Google Cloud DNS managed zone for your TFE FQDN.

--- a/load_balancing.tf
+++ b/load_balancing.tf
@@ -5,8 +5,9 @@
 # Common
 #------------------------------------------------------------------------------
 locals {
-  lb_name_suffix    = var.lb_is_internal ? "internal" : "external"
-  lb_use_shared_vip = var.lb_is_internal && !var.tfe_admin_console_disabled
+  lb_name_suffix      = var.lb_is_internal ? "internal" : "external"
+  lb_use_shared_vip   = var.lb_is_internal && !var.tfe_admin_console_disabled
+  lb_subnet_self_link = try(data.google_compute_subnetwork.lb_subnet[0].self_link, null)
 
   is_calver_tfe_image_tag  = can(regex("^v[0-9]{6}-[0-9]+$", var.tfe_image_tag))
   normalized_tfe_image_tag = trimprefix(var.tfe_image_tag, "v")
@@ -50,7 +51,7 @@ resource "google_compute_address" "tfe_frontend_lb" {
   address_type = var.lb_is_internal ? "INTERNAL" : "EXTERNAL"
   network_tier = var.lb_is_internal ? null : "PREMIUM"
   purpose      = local.lb_use_shared_vip ? "SHARED_LOADBALANCER_VIP" : null
-  subnetwork   = var.lb_is_internal ? data.google_compute_subnetwork.lb_subnet[0].self_link : null
+  subnetwork   = var.lb_is_internal ? local.lb_subnet_self_link : null
   address      = var.lb_is_internal ? var.lb_static_ip_address : null
 }
 
@@ -61,7 +62,7 @@ resource "google_compute_forwarding_rule" "tfe_frontend_lb" {
   load_balancing_scheme = var.lb_is_internal ? "INTERNAL" : "EXTERNAL"
   ports                 = [443]
   network               = var.lb_is_internal ? data.google_compute_network.vpc.self_link : null
-  subnetwork            = var.lb_is_internal ? data.google_compute_subnetwork.lb_subnet[0].self_link : null
+  subnetwork            = var.lb_is_internal ? local.lb_subnet_self_link : null
   ip_address            = google_compute_address.tfe_frontend_lb.address
 }
 
@@ -74,7 +75,7 @@ resource "google_compute_forwarding_rule" "tfe_admin_console_lb" {
   load_balancing_scheme = var.lb_is_internal ? "INTERNAL" : "EXTERNAL"
   ports                 = [var.tfe_admin_https_port]
   network               = var.lb_is_internal ? data.google_compute_network.vpc.self_link : null
-  subnetwork            = var.lb_is_internal ? data.google_compute_subnetwork.lb_subnet[0].self_link : null
+  subnetwork            = var.lb_is_internal ? local.lb_subnet_self_link : null
   ip_address            = google_compute_address.tfe_frontend_lb.address
 }
 

--- a/load_balancing.tf
+++ b/load_balancing.tf
@@ -7,7 +7,7 @@
 locals {
   lb_name_suffix      = var.lb_is_internal ? "internal" : "external"
   lb_use_shared_vip   = var.lb_is_internal && !var.tfe_admin_console_disabled
-  lb_subnet_self_link = try(data.google_compute_subnetwork.lb_subnet[0].self_link, null)
+  lb_subnet_self_link = var.lb_is_internal ? data.google_compute_subnetwork.lb_subnet[0].self_link : null
 
   is_calver_tfe_image_tag  = can(regex("^v[0-9]{6}-[0-9]+$", var.tfe_image_tag))
   normalized_tfe_image_tag = trimprefix(var.tfe_image_tag, "v")

--- a/load_balancing.tf
+++ b/load_balancing.tf
@@ -5,7 +5,8 @@
 # Common
 #------------------------------------------------------------------------------
 locals {
-  lb_name_suffix = var.lb_is_internal ? "internal" : "external"
+  lb_name_suffix    = var.lb_is_internal ? "internal" : "external"
+  lb_use_shared_vip = var.lb_is_internal && !var.tfe_admin_console_disabled
 
   is_calver_tfe_image_tag  = can(regex("^v[0-9]{6}-[0-9]+$", var.tfe_image_tag))
   normalized_tfe_image_tag = trimprefix(var.tfe_image_tag, "v")
@@ -48,6 +49,7 @@ resource "google_compute_address" "tfe_frontend_lb" {
   description  = "Static IP to associate with TFE load balancer forwarding rule (front end)."
   address_type = var.lb_is_internal ? "INTERNAL" : "EXTERNAL"
   network_tier = var.lb_is_internal ? null : "PREMIUM"
+  purpose      = local.lb_use_shared_vip ? "SHARED_LOADBALANCER_VIP" : null
   subnetwork   = var.lb_is_internal ? data.google_compute_subnetwork.lb_subnet[0].self_link : null
   address      = var.lb_is_internal ? var.lb_static_ip_address : null
 }


### PR DESCRIPTION
This pull request enhances support for internal load balancer deployments by enabling shared VIP (Virtual IP) semantics when the Admin Console is enabled. This allows both the main HTTPS endpoint and the Admin Console to share the same internal IP address. The changes also improve maintainability by centralizing subnet reference logic.

**Improvements for internal load balancer deployments:**

* The module now automatically reserves the frontend IP with shared VIP semantics (`SHARED_LOADBALANCER_VIP`) when the Admin Console is enabled, allowing both HTTPS (`443`) and the Admin Console port to share the same internal IP. [[1]](diffhunk://#diff-586ca75ad22cd1655951ccb2c705f109a16c9436fba162bf360b6cc64d96f5d3L51-R54) [[2]](diffhunk://#diff-dea719bc4ba0eea545a1ecd126d81a534e54b569f2612b3ad617f810014de695R55-R56)

**Code maintainability and consistency:**

* Introduced a new local variable `lb_subnet_self_link` to consistently reference the subnet self-link, reducing code duplication.
* Updated all relevant resources (`google_compute_address`, `google_compute_forwarding_rule` for both frontend and admin console) to use `local.lb_subnet_self_link` instead of repeating the subnet lookup logic. [[1]](diffhunk://#diff-586ca75ad22cd1655951ccb2c705f109a16c9436fba162bf360b6cc64d96f5d3L51-R54) [[2]](diffhunk://#diff-586ca75ad22cd1655951ccb2c705f109a16c9436fba162bf360b6cc64d96f5d3L62-R65) [[3]](diffhunk://#diff-586ca75ad22cd1655951ccb2c705f109a16c9436fba162bf360b6cc64d96f5d3L75-R78)## Summary
- reserve the internal frontend IP with `SHARED_LOADBALANCER_VIP` when the admin console forwarding rule is enabled
- allow ports 443 and the admin console port to share the same internal IP for internal load balancers
- document the shared VIP behavior for internal admin-console-enabled deployments

## Problem
Enabling the admin console on an internal load balancer created two forwarding rules on the same internal IP, but the reserved IP was not created with shared VIP semantics. GCP then rejected the second forwarding rule with `IP is already being used by another resource`.

## Testing
- `task test`
- branch-based deploy using `tfe_image_tag = "1.2.1"` with `tfe_admin_console_disabled = true`: apply succeeded, FQDN returned `301` on `443`, readiness returned `200`
- branch-based deploy using `tfe_image_tag = "1.2.1"` with `tfe_admin_console_disabled = false`: apply succeeded, FQDN returned `301` on `443`, readiness returned `200`, admin console returned `200` on `9443`