### PR TITLE
Fixed PostgreSQL machine type variables

### DIFF
--- a/examples/podman-rhel-internal-nlb/main.tf
+++ b/examples/podman-rhel-internal-nlb/main.tf
@@ -62,10 +62,11 @@ module "tfe" {
   cloud_dns_managed_zone_name = var.cloud_dns_managed_zone_name
 
   # --- Compute --- #
-  mig_instance_count = var.mig_instance_count
-  gce_image_name     = var.gce_image_name
-  gce_image_project  = var.gce_image_project
-  container_runtime  = var.container_runtime
+  mig_instance_count    = var.mig_instance_count
+  gce_image_name        = var.gce_image_name
+  gce_image_project     = var.gce_image_project
+  container_runtime     = var.container_runtime
+  postgres_machine_type = var.postgres_machine_type
 
   # --- Database --- #
   tfe_database_password_secret_id = var.tfe_database_password_secret_id

--- a/examples/podman-rhel-internal-nlb/terraform.tfvars.example
+++ b/examples/podman-rhel-internal-nlb/terraform.tfvars.example
@@ -39,6 +39,7 @@ mig_instance_count = 1
 gce_image_name     = "rhel-9-v20241009"
 gce_image_project  = "rhel-cloud"
 container_runtime  = "podman"
+postgres_machine_type = "db-perf-optimized-N-4" #Custom type no longer supported for PostgreSQL v16+
 
 # --- Database --- #
 tfe_database_password_secret_id = "<tfe-database-password-secret-name>"

--- a/examples/podman-rhel-internal-nlb/variables.tf
+++ b/examples/podman-rhel-internal-nlb/variables.tf
@@ -487,7 +487,7 @@ variable "postgres_availability_type" {
 variable "postgres_machine_type" {
   type        = string
   description = "Machine size of Cloud SQL for PostgreSQL instance."
-  default     = "db-custom-4-16384"
+  default     = "db-perf-optimized-N-4"
 }
 
 variable "postgres_disk_size" {

--- a/variables.tf
+++ b/variables.tf
@@ -487,7 +487,7 @@ variable "postgres_availability_type" {
 variable "postgres_machine_type" {
   type        = string
   description = "Machine size of Cloud SQL for PostgreSQL instance."
-  default     = "db-custom-4-16384"
+  default     = "db-perf-optimized-N-4"
 }
 
 variable "postgres_disk_size" {


### PR DESCRIPTION

## Description

PostgreSQL v16+ no longer supports custom machine types so switched to appropriate machine type 

## Related issue
[Link to the related issue (if applicable)]

## Type of change
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How has this been tested?
Tested end-to-end and deployment now completes without errors (previously generated errors related to these two issues and did not complete)

## Checklist
- [X ] My code follows the style guidelines of this project
- [X ] I have performed a self-review of my code
- [X ] I have commented my code, particularly in hard-to-understand areas
- [NA ] I have made corresponding changes to the documentation
- [X ] My changes generate no new warnings
- [ NA] I have added tests that prove my fix is effective or that my feature works
- [NA ] New and existing unit tests pass locally with my changes
- [NA ] Any dependent changes have been merged and published in downstream modules

## Additional notes
[Add any additional information or context about the PR here]
