### PR TITLE
fix: Updated PostgreSQL machine type & LB IP conflict & Database Resource Destruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Please note that there is no official Service Level Agreement (SLA) for support 
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | ~> 6.6 |
 | <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | ~> 6.6 |
@@ -157,7 +157,7 @@ Please note that there is no official Service Level Agreement (SLA) for support 
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_google"></a> [google](#provider\_google) | ~> 6.6 |
 | <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | ~> 6.6 |
 | <a name="provider_random"></a> [random](#provider\_random) | ~> 3.6 |
@@ -165,7 +165,7 @@ Please note that there is no official Service Level Agreement (SLA) for support 
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [google-beta_google_project_service_identity.gcp_project_cloud_sql_sa](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/google_project_service_identity) | resource |
 | [google_compute_address.tfe_frontend_lb](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_address) | resource |
 | [google_compute_firewall.vm_allow_ingress_ssh_from_cidr](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall) | resource |
@@ -175,7 +175,6 @@ Please note that there is no official Service Level Agreement (SLA) for support 
 | [google_compute_firewall.vm_allow_tfe_admin_console](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall) | resource |
 | [google_compute_firewall.vm_allow_tfe_metrics_from_cidr](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall) | resource |
 | [google_compute_firewall.vm_tfe_self_allow](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall) | resource |
-| [google_compute_forwarding_rule.tfe_admin_console_lb](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_forwarding_rule) | resource |
 | [google_compute_forwarding_rule.tfe_frontend_lb](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_forwarding_rule) | resource |
 | [google_compute_health_check.tfe_auto_healing](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_health_check) | resource |
 | [google_compute_instance_template.tfe](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance_template) | resource |
@@ -223,7 +222,7 @@ Please note that there is no official Service Level Agreement (SLA) for support 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_friendly_name_prefix"></a> [friendly\_name\_prefix](#input\_friendly\_name\_prefix) | Friendly name prefix used for uniquely naming all GCP resources for this deployment. Most commonly set to either an environment (e.g. 'sandbox', 'prod'), a team name, or a project name. | `string` | n/a | yes |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | ID of GCP project to deploy TFE in. | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | GCP region (location) to deploy TFE in. | `string` | n/a | yes |
@@ -274,7 +273,7 @@ Please note that there is no official Service Level Agreement (SLA) for support 
 | <a name="input_postgres_insights_config"></a> [postgres\_insights\_config](#input\_postgres\_insights\_config) | Configuration settings for Cloud SQL for PostgreSQL insights. | <pre>object({<br/>    query_insights_enabled  = bool<br/>    query_plans_per_minute  = number<br/>    query_string_length     = number<br/>    record_application_tags = bool<br/>    record_client_address   = bool<br/>  })</pre> | <pre>{<br/>  "query_insights_enabled": false,<br/>  "query_plans_per_minute": 5,<br/>  "query_string_length": 1024,<br/>  "record_application_tags": false,<br/>  "record_client_address": false<br/>}</pre> | no |
 | <a name="input_postgres_kms_cmek_name"></a> [postgres\_kms\_cmek\_name](#input\_postgres\_kms\_cmek\_name) | Name of Cloud KMS customer managed encryption key (CMEK) to use for Cloud SQL for PostgreSQL database instance. | `string` | `null` | no |
 | <a name="input_postgres_kms_keyring_name"></a> [postgres\_kms\_keyring\_name](#input\_postgres\_kms\_keyring\_name) | Name of Cloud KMS Key Ring that contains KMS key to use for Cloud SQL for PostgreSQL. Geographic location (region) of key ring must match the location of the TFE Cloud SQL for PostgreSQL database instance. | `string` | `null` | no |
-| <a name="input_postgres_machine_type"></a> [postgres\_machine\_type](#input\_postgres\_machine\_type) | Machine size of Cloud SQL for PostgreSQL instance. | `string` | `"db-custom-4-16384"` | no |
+| <a name="input_postgres_machine_type"></a> [postgres\_machine\_type](#input\_postgres\_machine\_type) | Machine size of Cloud SQL for PostgreSQL instance. | `string` | `"db-perf-optimized-N-4"` | no |
 | <a name="input_postgres_maintenance_window"></a> [postgres\_maintenance\_window](#input\_postgres\_maintenance\_window) | Optional maintenance window settings for the Cloud SQL for PostgreSQL instance. | <pre>object({<br/>    day          = number<br/>    hour         = number<br/>    update_track = string<br/>  })</pre> | <pre>{<br/>  "day": 7,<br/>  "hour": 0,<br/>  "update_track": "stable"<br/>}</pre> | no |
 | <a name="input_postgres_ssl_mode"></a> [postgres\_ssl\_mode](#input\_postgres\_ssl\_mode) | Indicates whether to enforce TLS/SSL connections to the Cloud SQL for PostgreSQL instance. | `string` | `"ENCRYPTED_ONLY"` | no |
 | <a name="input_postgres_version"></a> [postgres\_version](#input\_postgres\_version) | PostgreSQL version to use. | `string` | `"POSTGRES_16"` | no |
@@ -321,7 +320,7 @@ Please note that there is no official Service Level Agreement (SLA) for support 
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_tfe_admin_console_url_pattern"></a> [tfe\_admin\_console\_url\_pattern](#output\_tfe\_admin\_console\_url\_pattern) | URL pattern to access the TFE Admin Console. Only applicable when `tfe_admin_console_disabled` is `false`. |
 | <a name="output_tfe_create_initial_admin_user_url"></a> [tfe\_create\_initial\_admin\_user\_url](#output\_tfe\_create\_initial\_admin\_user\_url) | URL to create TFE initial admin user. |
 | <a name="output_tfe_database_host"></a> [tfe\_database\_host](#output\_tfe\_database\_host) | Private IP address and port of TFE Cloud SQL for PostgreSQL database instance. |

--- a/examples/docker-ubuntu-internal-nlb/main.tf
+++ b/examples/docker-ubuntu-internal-nlb/main.tf
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2024, 2025
+# Copyright IBM Corp. 2024, 2025, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 terraform {
@@ -62,10 +62,11 @@ module "tfe" {
   cloud_dns_managed_zone_name = var.cloud_dns_managed_zone_name
 
   # --- Compute --- #
-  mig_instance_count = var.mig_instance_count
-  gce_image_name     = var.gce_image_name
-  gce_image_project  = var.gce_image_project
-  container_runtime  = var.container_runtime
+  mig_instance_count    = var.mig_instance_count
+  gce_image_name        = var.gce_image_name
+  gce_image_project     = var.gce_image_project
+  container_runtime     = var.container_runtime
+  postgres_machine_type = var.postgres_machine_type
 
   # --- Database --- #
   tfe_database_password_secret_id = var.tfe_database_password_secret_id

--- a/examples/docker-ubuntu-internal-nlb/terraform.tfvars.example
+++ b/examples/docker-ubuntu-internal-nlb/terraform.tfvars.example
@@ -39,6 +39,7 @@ mig_instance_count = 1
 gce_image_name     = "ubuntu-pro-2404-noble-amd64-v20241004"
 gce_image_project  = "ubuntu-os-pro-cloud"
 container_runtime  = "docker"
+postgres_machine_type = "db-perf-optimized-N-4" #Custom type no longer supported for PostgreSQL v16+
 
 # --- Database --- #
 tfe_database_password_secret_id = "<tfe-database-password-secret-name>"

--- a/examples/docker-ubuntu-internal-nlb/variables.tf
+++ b/examples/docker-ubuntu-internal-nlb/variables.tf
@@ -487,7 +487,7 @@ variable "postgres_availability_type" {
 variable "postgres_machine_type" {
   type        = string
   description = "Machine size of Cloud SQL for PostgreSQL instance."
-  default     = "db-custom-4-16384"
+  default     = "db-perf-optimized-N-4"
 }
 
 variable "postgres_disk_size" {

--- a/examples/podman-rhel-internal-nlb/main.tf
+++ b/examples/podman-rhel-internal-nlb/main.tf
@@ -62,10 +62,11 @@ module "tfe" {
   cloud_dns_managed_zone_name = var.cloud_dns_managed_zone_name
 
   # --- Compute --- #
-  mig_instance_count = var.mig_instance_count
-  gce_image_name     = var.gce_image_name
-  gce_image_project  = var.gce_image_project
-  container_runtime  = var.container_runtime
+  mig_instance_count    = var.mig_instance_count
+  gce_image_name        = var.gce_image_name
+  gce_image_project     = var.gce_image_project
+  container_runtime     = var.container_runtime
+  postgres_machine_type = var.postgres_machine_type
 
   # --- Database --- #
   tfe_database_password_secret_id = var.tfe_database_password_secret_id

--- a/examples/podman-rhel-internal-nlb/main.tf
+++ b/examples/podman-rhel-internal-nlb/main.tf
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2024, 2025
+# Copyright IBM Corp. 2024, 2025, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 terraform {

--- a/examples/podman-rhel-internal-nlb/terraform.tfvars.example
+++ b/examples/podman-rhel-internal-nlb/terraform.tfvars.example
@@ -39,6 +39,7 @@ mig_instance_count = 1
 gce_image_name     = "rhel-9-v20241009"
 gce_image_project  = "rhel-cloud"
 container_runtime  = "podman"
+postgres_machine_type = "db-perf-optimized-N-4" #Custom type no longer supported for PostgreSQL v16+
 
 # --- Database --- #
 tfe_database_password_secret_id = "<tfe-database-password-secret-name>"

--- a/examples/podman-rhel-internal-nlb/variables.tf
+++ b/examples/podman-rhel-internal-nlb/variables.tf
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2024, 2025
+# Copyright IBM Corp. 2024, 2025, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 #------------------------------------------------------------------------------

--- a/examples/podman-rhel-internal-nlb/variables.tf
+++ b/examples/podman-rhel-internal-nlb/variables.tf
@@ -487,7 +487,7 @@ variable "postgres_availability_type" {
 variable "postgres_machine_type" {
   type        = string
   description = "Machine size of Cloud SQL for PostgreSQL instance."
-  default     = "db-custom-4-16384"
+  default     = "db-perf-optimized-N-4"
 }
 
 variable "postgres_disk_size" {

--- a/load_balancing.tf
+++ b/load_balancing.tf
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2024, 2025
+# Copyright IBM Corp. 2024, 2025, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 #------------------------------------------------------------------------------

--- a/load_balancing.tf
+++ b/load_balancing.tf
@@ -52,7 +52,9 @@ resource "google_compute_address" "tfe_frontend_lb" {
   address      = var.lb_is_internal ? var.lb_static_ip_address : null
 }
 
-/**
+# Merged duplicate forwarding rule resources to support optional admin console port forwarding when enabled
+# Prevents IP address conflict error that otherwise occurs when both forwarding rules are created with the same IP address.
+/**  
 resource "google_compute_forwarding_rule" "tfe_frontend_lb" {
   name                  = "${var.friendly_name_prefix}-tfe-frontend-lb-${local.lb_name_suffix}"
   backend_service       = google_compute_region_backend_service.tfe_backend_lb.id

--- a/load_balancing.tf
+++ b/load_balancing.tf
@@ -52,6 +52,7 @@ resource "google_compute_address" "tfe_frontend_lb" {
   address      = var.lb_is_internal ? var.lb_static_ip_address : null
 }
 
+/**
 resource "google_compute_forwarding_rule" "tfe_frontend_lb" {
   name                  = "${var.friendly_name_prefix}-tfe-frontend-lb-${local.lb_name_suffix}"
   backend_service       = google_compute_region_backend_service.tfe_backend_lb.id
@@ -62,15 +63,15 @@ resource "google_compute_forwarding_rule" "tfe_frontend_lb" {
   subnetwork            = var.lb_is_internal ? data.google_compute_subnetwork.lb_subnet[0].self_link : null
   ip_address            = google_compute_address.tfe_frontend_lb.address
 }
+**/
 
-resource "google_compute_forwarding_rule" "tfe_admin_console_lb" {
-  count = var.tfe_admin_console_disabled ? 0 : 1
+resource "google_compute_forwarding_rule" "tfe_frontend_lb" {
 
-  name                  = "${var.friendly_name_prefix}-tfe-admin-console-lb-${local.lb_name_suffix}"
+  name                  = "${var.friendly_name_prefix}-tfe-frontend-lb-${local.lb_name_suffix}"
   backend_service       = google_compute_region_backend_service.tfe_backend_lb.id
   ip_protocol           = "TCP"
   load_balancing_scheme = var.lb_is_internal ? "INTERNAL" : "EXTERNAL"
-  ports                 = [var.tfe_admin_https_port]
+  ports                 = var.tfe_admin_console_disabled ? [443] : [443, var.tfe_admin_https_port] #Adds forwarding to admin port as well if enabled; default 9443
   network               = var.lb_is_internal ? data.google_compute_network.vpc.self_link : null
   subnetwork            = var.lb_is_internal ? data.google_compute_subnetwork.lb_subnet[0].self_link : null
   ip_address            = google_compute_address.tfe_frontend_lb.address

--- a/postgresql.tf
+++ b/postgresql.tf
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2024, 2025
+# Copyright IBM Corp. 2024, 2025, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 #------------------------------------------------------------------------------

--- a/postgresql.tf
+++ b/postgresql.tf
@@ -62,12 +62,14 @@ resource "google_sql_database_instance" "tfe" {
 resource "google_sql_database" "tfe" {
   name     = var.tfe_database_name
   instance = google_sql_database_instance.tfe.name
+  deletion_policy = "ABANDON"
 }
 
 resource "google_sql_user" "tfe" {
   name     = var.tfe_database_user
   instance = google_sql_database_instance.tfe.name
   password = data.google_secret_manager_secret_version.tfe_database_password.secret_data
+  deletion_policy = "ABANDON"
 }
 
 #------------------------------------------------------------------------------

--- a/variables.tf
+++ b/variables.tf
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2024, 2025
+# Copyright IBM Corp. 2024, 2025, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 #------------------------------------------------------------------------------

--- a/variables.tf
+++ b/variables.tf
@@ -487,7 +487,7 @@ variable "postgres_availability_type" {
 variable "postgres_machine_type" {
   type        = string
   description = "Machine size of Cloud SQL for PostgreSQL instance."
-  default     = "db-custom-4-16384"
+  default     = "db-perf-optimized-N-4"
 }
 
 variable "postgres_disk_size" {


### PR DESCRIPTION
## Description

1. Custom machine types are no longer supported in GCP for PostgreSQL v16+.  This PR updates the variable references, defaults, and examples to pass the new equivalent machine type
2. Merged forwarding rules resources for LB with conditional for if admin console is enabled to address LB IP conflict by having two resources
3. Set SQL database & SQL user resource deletion policies to "ABANDON" to allow them to be correctly destroyed because default of "DELETE" is known to time out based on GCP backend activity, and instance destruction usually follows anyways, per guidance in the provider.
4. Updated readme with new default for 1 and terraform-docs-generated formatting


## Related issue
[Link to the related issue (if applicable)]

## Type of change
- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How has this been tested?
Ran end-to-end deployment.

## Checklist
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [NA] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [NA] I have added tests that prove my fix is effective or that my feature works
- [NA] New and existing unit tests pass locally with my changes
- [NA] Any dependent changes have been merged and published in downstream modules

## Additional notes
[Add any additional information or context about the PR here]
