### PR TITLE
feat(variables): add validation to tfe_image_tag variable

### DIFF
--- a/examples/docker-ubuntu-internal-nlb/variables.tf
+++ b/examples/docker-ubuntu-internal-nlb/variables.tf
@@ -80,6 +80,15 @@ variable "tfe_image_tag" {
   type        = string
   description = "Tag (release) for the TFE container image. This represents which version (release) of TFE to deploy."
   default     = "1.2.1"
+
+  validation {
+    condition = (
+      can(regex("^v[0-9]{6}-[0-9]+$", var.tfe_image_tag)) ||
+      can(regex("^v?[0-9]+\\.[0-9]+(\\.[0-9]+)?$", var.tfe_image_tag)) ||
+      can(regex("^[0-9a-f]{7,}$", var.tfe_image_tag))
+    )
+    error_message = "tfe_image_tag must be a supported calver tag (for example v202409-3), semver tag (for example 1.2.1 or v1.2.1), or raw commit hash."
+  }
 }
 
 variable "tfe_image_repository_username" {

--- a/examples/podman-rhel-internal-nlb/variables.tf
+++ b/examples/podman-rhel-internal-nlb/variables.tf
@@ -80,6 +80,15 @@ variable "tfe_image_tag" {
   type        = string
   description = "Tag (release) for the TFE container image. This represents which version (release) of TFE to deploy."
   default     = "1.2.1"
+
+  validation {
+    condition = (
+      can(regex("^v[0-9]{6}-[0-9]+$", var.tfe_image_tag)) ||
+      can(regex("^v?[0-9]+\\.[0-9]+(\\.[0-9]+)?$", var.tfe_image_tag)) ||
+      can(regex("^[0-9a-f]{7,}$", var.tfe_image_tag))
+    )
+    error_message = "tfe_image_tag must be a supported calver tag (for example v202409-3), semver tag (for example 1.2.1 or v1.2.1), or raw commit hash."
+  }
 }
 
 variable "tfe_image_repository_username" {

--- a/variables.tf
+++ b/variables.tf
@@ -80,6 +80,15 @@ variable "tfe_image_tag" {
   type        = string
   description = "Tag (release) for the TFE container image. This represents which version (release) of TFE to deploy."
   default     = "1.2.1"
+
+  validation {
+    condition = (
+      can(regex("^v[0-9]{6}-[0-9]+$", var.tfe_image_tag)) ||
+      can(regex("^v?[0-9]+\\.[0-9]+(\\.[0-9]+)?$", var.tfe_image_tag)) ||
+      can(regex("^[0-9a-f]{7,}$", var.tfe_image_tag))
+    )
+    error_message = "tfe_image_tag must be a supported calver tag (for example v202409-3), semver tag (for example 1.2.1 or v1.2.1), or raw commit hash."
+  }
 }
 
 variable "tfe_image_repository_username" {


### PR DESCRIPTION
## Description
Add input validation to the `tfe_image_tag` variable to enforce accepted tag formats and surface a clear error message when an unsupported value is supplied.

## Related issue
Closes #26

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How has this been tested
- Validation block accepts the current default (`1.2.1`) and representative calver, semver, and commit-hash values.
- `terraform validate` passes against the root module and both example configurations.
- README.md regenerated with `terraform-docs`.

## Accepted formats
| Format | Example |
|---|---|
| CalVer | `v202409-3` |
| SemVer (with or without `v`) | `1.2.1` / `v1.2.1` |
| Commit hash (>=7 chars) | `abc1234` |

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] `terraform fmt` passes
- [x] `terraform validate` passes